### PR TITLE
Working GICv3 driver

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [stable, 1.76]
+        rust: [stable, 1.82]
         target:
           - armebv7r-none-eabi
           - armebv7r-none-eabihf
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [stable, 1.76]
+        rust: [stable, 1.82]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [stable, 1.76]
+        rust: [stable, 1.82]
         target:
           - armebv7r-none-eabi
           - armebv7r-none-eabihf
@@ -93,7 +93,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [stable, 1.76]
+        rust: [stable, 1.82]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -137,7 +137,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [stable, 1.76]
+        rust: [stable, 1.82]
         target:
           - armebv7r-none-eabi
           - armebv7r-none-eabihf
@@ -160,7 +160,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [stable, 1.76]
+        rust: [stable, 1.82]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,8 @@ members = [
     "cortex-r",
     "cortex-r-examples",
     "cortex-r-rt",
-    "arm-semihosting"
+    "arm-semihosting",
+    "arm-gic"
 ]
 exclude = [
     "arm-targets"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ There are currently three libraries here:
 * [cortex-r-rt](./cortex-r-rt/) - run-time library for Cortex-R CPUs (like [cortex-m-rt])
 * [arm-semihosting](./arm-semihosting/) - semihosting library for many kinds of Arm CPU (like [cortex-m-semihosting])
 * [arm-targets](./arm-targets/) - a helper library for your build.rs that sets various `--cfg` flags according to the current target
+* [arm-gic](./arm-gic/) - A port of <https://github.com/google/arm-gic> to AArch32
 
 There are also example programs for QEMU in the [cortex-r-examples](./cortex-r-examples/) folder.
 

--- a/arm-gic/.cargo/config.toml
+++ b/arm-gic/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "aarch64-unknown-none"

--- a/arm-gic/.github/dependabot.yml
+++ b/arm-gic/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/arm-gic/.github/workflows/rust.yml
+++ b/arm-gic/.github/workflows/rust.yml
@@ -1,0 +1,35 @@
+name: Rust
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install aarch64 toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: aarch64-unknown-none
+      - name: Build
+        run: cargo build
+      - name: Run clippy
+        uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Test on host
+        run: cargo test --target=x86_64-unknown-linux-gnu --lib
+
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Format Rust code
+        run: cargo fmt --all -- --check

--- a/arm-gic/.gitignore
+++ b/arm-gic/.gitignore
@@ -1,0 +1,2 @@
+/target
+/.vscode

--- a/arm-gic/AUTHORS
+++ b/arm-gic/AUTHORS
@@ -1,0 +1,7 @@
+# This is the list of arm-gic's significant contributors.
+#
+# This does not necessarily list everyone who has contributed code,
+# especially since many employees of one corporation may be contributing.
+# To see the full list of contributors, see the revision history in
+# source control.
+Google LLC

--- a/arm-gic/CHANGELOG.md
+++ b/arm-gic/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+## Unreleased
+
+### Bugfixes
+
+- Fixed `GicV3::setup` not to write to GICD IGROUPR[0].
+
+### Improvements
+
+- Added more interrupt types to `IntId`, and public constants for number of each type.
+- Added constants to `IntId` for special interrupt IDs.
+- Added methods to read type register and its fields.
+
+## 0.1.2
+
+### Bugfixes
+
+- Changed `irouter` and `irouter_e` fields of `GICD` to use u64, to match GIC specification.
+
+### Improvements
+
+- Made `gicv3::registers` module public and added methods to `GicV3` to get pointers to registers.
+
+## 0.1.1
+
+### Improvements
+
+- Implemented `Send` and `Sync` for `GicV3`.
+
+## 0.1.0
+
+Initial version, with basic support for GICv3 (and 4) on aarch64.

--- a/arm-gic/CONTRIBUTING.md
+++ b/arm-gic/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+# How to Contribute
+
+We'd love to accept your patches and contributions to this project. There are just a few small
+guidelines you need to follow.
+
+## Contributor License Agreement
+
+Contributions to this project must be accompanied by a Contributor License Agreement (CLA). You (or
+your employer) retain the copyright to your contribution; this simply gives us permission to use and
+redistribute your contributions as part of the project. Head over to
+<https://cla.developers.google.com/> to see your current agreements on file or to sign a new one.
+
+You generally only need to submit a CLA once, so if you've already submitted one (even if it was for
+a different project), you probably don't need to do it again.
+
+## Code Reviews
+
+All submissions, including submissions by project members, require review. We use GitHub pull
+requests for this purpose. Consult
+[GitHub Help](https://help.github.com/articles/about-pull-requests/) for more information on using
+pull requests.
+
+## Community Guidelines
+
+This project follows
+[Google's Open Source Community Guidelines](https://opensource.google/conduct/).

--- a/arm-gic/Cargo.toml
+++ b/arm-gic/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "arm-gic"
+version = "0.1.2"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+description = "A driver for the Arm Generic Interrupt Controller version 2, 3 or 4."
+authors = ["Andrew Walbran <qwandor@google.com>", "Fritz Stracke <fritz.stracke@rwth-aachen.de>"]
+repository = "https://github.com/google/arm-gic"
+keywords = ["arm", "aarch64", "driver", "gic", "interrupt-controller"]
+categories = ["embedded", "no-std", "hardware-support"]
+
+[dependencies]
+bitflags = "2.8.0"
+thiserror = { version="2.0.11", default-features = false }

--- a/arm-gic/LICENSE
+++ b/arm-gic/LICENSE
@@ -1,0 +1,229 @@
+This project is dual-licensed under Apache 2.0 and MIT terms.
+
+====
+
+MIT License
+
+Copyright (c) 2020 The cloudbbq authors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+====
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/arm-gic/LICENSE-APACHE
+++ b/arm-gic/LICENSE-APACHE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/arm-gic/LICENSE-MIT
+++ b/arm-gic/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 The cloudbbq authors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/arm-gic/README.md
+++ b/arm-gic/README.md
@@ -1,0 +1,39 @@
+# Arm Generic Interrupt Controller driver
+
+[![crates.io page](https://img.shields.io/crates/v/arm-gic.svg)](https://crates.io/crates/arm-gic)
+[![docs.rs page](https://docs.rs/arm-gic/badge.svg)](https://docs.rs/arm-gic)
+
+This crate provides a Rust driver for the Arm Generic Interrupt Controller version 3 or 4 (GICv3 and
+GICv4) as well as verison 2.
+
+Because of large technical differences between the version 2 and version 3/4 Generic Interrupt Controllers
+they have been separated in different modules. Use the one appropriate for your hardware. The interfaces are
+largely compatible. Only differences when dispatching software-generated interrupts should be considered.
+Look at the ARM-Manuals for further details.
+
+Currently it only supports AArch64. Patches are welcome to add support for AArch32 and other GIC
+versions.
+
+This is not an officially supported Google product.
+
+## IMPORTANT NOTE
+
+This copy has been modified to work on Armv8-R AArch32 instead of Armv8-A
+AArch64. The changes in `sysreg.rs` should be changed to work with, and not
+replace, the AArch64 code.
+
+## License
+
+Licensed under either of
+
+- Apache License, Version 2.0
+  ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+- MIT license
+  ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.
+
+## Contributing
+
+If you want to contribute to the project, see details of
+[how we accept contributions](CONTRIBUTING.md).

--- a/arm-gic/src/gicv2.rs
+++ b/arm-gic/src/gicv2.rs
@@ -1,0 +1,219 @@
+// Copyright 2025 The arm-gic Authors.
+// This project is dual-licensed under Apache 2.0 and MIT terms.
+// See LICENSE-APACHE and LICENSE-MIT for details.
+
+//! Driver for the Arm Generic Interrupt Controller version 2.
+
+mod registers;
+
+use self::registers::{GicdCtlr, GICC, GICD};
+use crate::{IntId, Trigger};
+
+/// Driver for an Arm Generic Interrupt Controller version 2.
+#[derive(Debug)]
+pub struct GicV2 {
+    gicd: *mut GICD,
+    gicc: *mut GICC,
+}
+
+impl GicV2 {
+    /// Constructs a new instance of the driver for a GIC with the given distributor and
+    /// controller base addresses.
+    ///
+    /// # Safety
+    ///
+    /// The given base addresses must point to the GIC distributor and controller registers
+    /// respectively. These regions must be mapped into the address space of the process as device
+    /// memory, and not have any other aliases, either via another instance of this driver or
+    /// otherwise.
+    pub unsafe fn new(gicd: *mut u64, gicc: *mut u64) -> Self {
+        Self {
+            gicd: gicd as _,
+            gicc: gicc as _,
+        }
+    }
+
+    /// Get the maximum number of IRQs supported
+    pub fn max_irqs(&self) -> u32 {
+        // SAFETY: We know that `self.gicd` is a valid and unique pointer to the registers of a
+        // GIC distributor interface.
+        unsafe { (((&raw const (*self.gicd).typer).read_volatile() as u32 & 0b11111) + 1) * 32 }
+    }
+
+    /// Initialises the GIC.
+    pub fn setup(&mut self) {
+        // SAFETY: Both registers `self.gicd` and `self.gicc` are valid and unique pointers to
+        // the hardware interfaces provided by the user.
+        unsafe {
+            (&raw mut (*self.gicd).ctlr).write_volatile(GicdCtlr::EnableGrp1);
+            for i in 0..32 {
+                (&raw mut (*self.gicd).igroupr[i]).write_volatile(0xffffffff);
+            }
+
+            (&raw mut (*self.gicc).ctlr).write_volatile(0b1);
+            (&raw mut (*self.gicc).pmr).write_volatile(0xff);
+        }
+    }
+
+    /// Enables or disables the interrupt with the given ID.
+    pub fn enable_interrupt(&mut self, intid: IntId, enable: bool) -> Result<(), ()> {
+        let index = (intid.0 / 32) as usize;
+        let bit = 1 << (intid.0 % 32);
+
+        if enable {
+            // SAFETY: We know that `self.gicd` is a valid and unique pointer to the registers of a
+            // GIC distributor interface.
+            unsafe {
+                (&raw mut (*self.gicd).isenabler[index]).write_volatile(bit);
+                if ((&raw const (*self.gicd).isenabler[index]).read_volatile() & bit) == 0 {
+                    return Err(());
+                }
+            }
+            Ok(())
+        } else {
+            // SAFETY: We know that `self.gicd` is a valid and unique pointer to the registers of a
+            // GIC distributor interface.
+            unsafe {
+                (&raw mut (*self.gicd).icenabler[index]).write(bit);
+            }
+            Ok(())
+        }
+    }
+
+    /// Enables all interrupts.
+    pub fn enable_all_interrupts(&mut self, enable: bool) {
+        for i in 0..32 {
+            if enable {
+                // SAFETY: We know that `self.gicd` is a valid and unique pointer to the registers
+                // of a GIC distributor interface.
+                unsafe {
+                    (&raw mut (*self.gicd).isenabler[i]).write_volatile(0xffffffff);
+                }
+            } else {
+                // SAFETY: We know that `self.gicd` is a valid and unique pointer to the registers
+                // of a GIC distributor interface.
+                unsafe {
+                    (&raw mut (*self.gicd).icenabler[i]).write_volatile(0xffffffff);
+                }
+            }
+        }
+    }
+
+    /// Sets the priority mask for the current CPU core.
+    ///
+    /// Only interrupts with a higher priority (numerically lower) will be signalled.
+    pub fn set_priority_mask(&mut self, min_priority: u8) {
+        // SAFETY: The existence of the PMR Register is guaranteed by the user.
+        unsafe {
+            (&raw mut (*self.gicc).pmr).write_volatile(min_priority as u32);
+        }
+    }
+
+    /// Sets the priority of the interrupt with the given ID.
+    ///
+    /// Note that lower numbers correspond to higher priorities; i.e. 0 is the highest priority, and
+    /// 255 is the lowest.
+    pub fn set_interrupt_priority(&mut self, intid: IntId, priority: u8) {
+        let idx = intid.0 as usize / 4;
+        let priority = (priority as u32) << (8 * (intid.0 % 4));
+        // SAFETY: We know that `self.gicd` is a valid and unique pointer to the registers of a
+        // GIC distributor interface.
+        unsafe {
+            (&raw mut (*self.gicd).ipriorityr[idx]).write_volatile(priority);
+        }
+    }
+
+    /// Configures the trigger type for the interrupt with the given ID.
+    pub fn set_trigger(&mut self, intid: IntId, trigger: Trigger) {
+        let index = (intid.0 / 16) as usize;
+        let bit = 1 << (((intid.0 % 16) * 2) + 1);
+
+        // SAFETY: We know that `self.gicd` is a valid and unique pointer to the registers of a
+        // GIC distributor interface.
+        // Affinity routing is not available. So instead use the icfgr register present on all
+        // GICD interfaces (present as guaranteed by the user) to set trigger modes.
+        unsafe {
+            let register = (&raw mut (*self.gicd).icfgr[index]);
+            let v = register.read_volatile();
+            register.write_volatile(match trigger {
+                Trigger::Edge => v | bit,
+                Trigger::Level => v & !bit,
+            });
+        }
+    }
+
+    /// Sends a software-generated interrupt (SGI) to the given cores.
+    pub fn send_sgi(&mut self, intid: IntId, target: SgiTarget) {
+        assert!(intid.is_sgi());
+
+        let sgi_value = match target {
+            SgiTarget::All => (u32::from(intid.0 & 0x0f)) | (0xff << 16),
+            SgiTarget::List {
+                target_list_filter,
+                target_list,
+            } => {
+                u32::from(intid.0 & 0xf)
+                    | u32::from(
+                        match target_list_filter {
+                            SgiTargetListFilter::CPUTargetList => 0b00 as u32,
+                            SgiTargetListFilter::ForwardOthersOnly => 0b01 as u32,
+                            SgiTargetListFilter::ForwardSelfOnly => 0b10 as u32,
+                        } << 24,
+                    )
+                    | u32::from(((target_list & 0xff) as u32) << 16)
+                    | (1u32 << 15)
+            }
+        };
+
+        // SAFETY: As guaranteed by the user, the gicd is a valid pointer to a GIC distributor
+        // which always contains the sgir register.
+        unsafe {
+            (&raw mut (*self.gicd).sgir).write_volatile(sgi_value);
+        }
+    }
+
+    /// Gets the ID of the highest priority signalled interrupt, and acknowledges it.
+    ///
+    /// Returns `None` if there is no ptending interrupt of sufficient priority.
+    pub fn get_and_acknowledge_interrupt(&mut self) -> Option<IntId> {
+        let intid: u32;
+
+        // SAFETY: This memory access is guaranteed by the user passing along a valid GICD address.
+        unsafe {
+            intid = (&raw mut (*self.gicc).aiar).read_volatile() as u32;
+        }
+        if intid == IntId::SPECIAL_START {
+            None
+        } else {
+            Some(IntId(intid))
+        }
+    }
+
+    /// Informs the interrupt controller that the CPU has completed processing the given interrupt.
+    /// This drops the interrupt priority and deactivates the interrupt.
+    pub fn end_interrupt(&mut self, intid: IntId) {
+        // SAFETY: The gicc is a valid pointer as guaranteed by the user. The aeoir register is always present.
+        unsafe {
+            (&raw mut (*self.gicc).aeoir).write_volatile(intid.0);
+        }
+    }
+}
+
+/// The target specification for a software-generated interrupt.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum SgiTarget {
+    /// The SGI is routed to all CPU cores except the current one.
+    All,
+    /// The SGI is routed to the CPU cores matching the given affinities and list.
+    List {
+        target_list_filter: SgiTargetListFilter,
+        target_list: u16,
+    },
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum SgiTargetListFilter {
+    CPUTargetList,
+    ForwardOthersOnly,
+    ForwardSelfOnly,
+}

--- a/arm-gic/src/gicv2/registers.rs
+++ b/arm-gic/src/gicv2/registers.rs
@@ -1,0 +1,79 @@
+// Copyright 2025 The arm-gic Authors.
+// This project is dual-licensed under Apache 2.0 and MIT terms.
+// See LICENSE-APACHE and LICENSE-MIT for details.
+use bitflags::bitflags;
+
+bitflags! {
+    #[repr(transparent)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    pub struct GicdCtlr: u32 {
+        const EnableGrp1 = 1 << 1;
+        const EnableGrp0 = 1 << 0;
+    }
+}
+
+#[repr(C, align(8))]
+pub struct GICD {
+    /// Distributor Control Register
+    pub ctlr: GicdCtlr,
+    /// Interrupt Controller Type Register
+    pub typer: u32,
+    /// Distributor Implementer Identification Register.
+    pub iidr: u32,
+    _reserved_0: [u32; 0x1D],
+    /// Interrupt Group Registers
+    pub igroupr: [u32; 0x20],
+    /// Interrupt Set-Enable Registers.
+    pub isenabler: [u32; 0x20],
+    /// Interrupt Clear-Enable Registers.
+    pub icenabler: [u32; 0x20],
+    /// Interrupt Set-Pending Registers.
+    pub ispendr: [u32; 0x20],
+    /// Interrupt Clear-Pending Registers.
+    pub icpendr: [u32; 0x20],
+    /// Interrupt Set-Active Registers.
+    pub isactiver: [u32; 0x20],
+    /// Interrupt Clear-Active Registers.
+    pub icactiver: [u32; 0x20],
+    /// Interrupt Priority Registers.
+    pub ipriorityr: [u32; 0x100],
+    /// Interrupt Processor Targets Registers.
+    pub itargetsr: [u32; 0x100],
+    /// Interrupt Configuration Registers.
+    pub icfgr: [u32; 0x40],
+    _reserved_1: [u32; 0x80],
+    /// Software Generated Interrupt Register.
+    pub sgir: u32,
+}
+
+#[repr(C, align(8))]
+pub struct GICC {
+    /// CPU Interface Control Register.
+    pub ctlr: u32,
+    /// Interrupt Priority Mask Register.
+    pub pmr: u32,
+    /// Binary Point Register.
+    pub bpr: u32,
+    /// Interrupt Acknowledge Register.
+    pub iar: u32,
+    /// End of Interrupt Register.
+    pub eoir: u32,
+    /// Running Priority Register.
+    pub rpr: u32,
+    /// Highest Priority Pending Interrupt Register.
+    pub hppir: u32,
+    /// Aliased Binary Point Register
+    pub abpr: u32,
+    /// Aliased Interrupt Acknwoledge Register
+    pub aiar: u32,
+    /// Aliased End of Interrupt Register
+    pub aeoir: u32,
+    /// Aliased Highest Priority Pending Interrupt Register
+    pub ahppir: u32,
+    _reserved_0: [u32; 0x34],
+    /// CPU Interface Identification Register.
+    pub iidr: u32,
+    _reserved_1: [u32; 0x3C0],
+    /// Deactivate Interrupt Register.
+    pub dir: u32,
+}

--- a/arm-gic/src/gicv3.rs
+++ b/arm-gic/src/gicv3.rs
@@ -1,0 +1,465 @@
+// Copyright 2023 The arm-gic Authors.
+// This project is dual-licensed under Apache 2.0 and MIT terms.
+// See LICENSE-APACHE and LICENSE-MIT for details.
+
+//! Driver for the Arm Generic Interrupt Controller version 3 (or 4).
+
+pub mod registers;
+
+use self::registers::{GicdCtlr, GicrCtlr, Waker, GICD, GICR, SGI};
+use crate::sysreg::{
+    read_icc_iar1_el1, write_icc_ctlr_el1, write_icc_eoir1_el1, write_icc_igrpen1_el1,
+    write_icc_pmr_el1, write_icc_sgi1r_el1, write_icc_sre_el1,
+};
+use crate::{IntId, Trigger};
+use core::hint::spin_loop;
+use registers::Typer;
+use thiserror::Error;
+
+/// The offset in bytes from `RD_base` to `SGI_base`.
+const SGI_OFFSET: usize = 0x10000;
+
+/// An error which may be returned from operations on a GIC Redistributor.
+#[derive(Error, Debug, Clone, Copy, Eq, PartialEq)]
+pub enum GICRError {
+    #[error("Redistributor has already been notified that the connected core is awake")]
+    AlreadyAwake,
+}
+
+/// Modifies `nth` bit of memory pointed by `registers`.
+///
+/// # Safety
+///
+/// The caller must ensure that `registers` is a valid pointer for volatile reads and writes.
+unsafe fn modify_bit(registers: *mut [u32], nth: usize, set_bit: bool) {
+    let reg_num: usize = nth / 32;
+
+    let bit_num: usize = nth % 32;
+    let bit_mask: u32 = 1 << bit_num;
+
+    // SAFETY: `registers` is guaranteed to be
+    // a valid pointer for volatile reads and writes
+    // and `reg_num` does not exceed `*registers` length.
+    unsafe {
+        let reg_ptr = &raw mut (*registers)[reg_num];
+        let old_value = reg_ptr.read_volatile();
+
+        let new_value: u32 = if set_bit {
+            old_value | bit_mask
+        } else {
+            old_value & !bit_mask
+        };
+
+        reg_ptr.write_volatile(new_value);
+    }
+}
+
+/// Sets `nth` bit of memory pointed by `registers`.
+///
+/// # Safety
+///
+/// The caller must ensure that `registers` is a valid
+/// pointer for volatile reads and writes.
+unsafe fn set_bit(registers: *mut [u32], nth: usize) {
+    modify_bit(registers, nth, true);
+}
+
+/// Clears `nth` bit of memory pointed by `registers`.
+///
+/// # Safety
+///
+/// The caller must ensure that `registers` is a valid
+/// pointer for volatile reads and writes.
+unsafe fn clear_bit(registers: *mut [u32], nth: usize) {
+    modify_bit(registers, nth, false);
+}
+
+/// Driver for an Arm Generic Interrupt Controller version 3 (or 4).
+#[derive(Debug)]
+pub struct GicV3 {
+    gicd: *mut GICD,
+    gicr: *mut GICR,
+    sgi: *mut SGI,
+}
+
+impl GicV3 {
+    /// Constructs a new instance of the driver for a GIC with the given distributor and
+    /// redistributor base addresses.
+    ///
+    /// # Safety
+    ///
+    /// The given base addresses must point to the GIC distributor and redistributor registers
+    /// respectively. These regions must be mapped into the address space of the process as device
+    /// memory, and not have any other aliases, either via another instance of this driver or
+    /// otherwise.
+    pub unsafe fn new(gicd: *mut u64, gicr: *mut u64) -> Self {
+        Self {
+            gicd: gicd as _,
+            gicr: gicr as _,
+            sgi: gicr.wrapping_byte_add(SGI_OFFSET) as _,
+        }
+    }
+
+    /// Initialises the GIC.
+    pub fn setup(&mut self) {
+        // Enable system register access.
+        write_icc_sre_el1(0x01);
+
+        // Ignore error in case core is already awake.
+        let _ = self.redistributor_mark_core_awake();
+
+        // Disable use of `ICC_PMR_EL1` as a hint for interrupt distribution, configure a write to
+        // an EOI register to also deactivate the interrupt, and configure preemption groups for
+        // group 0 and group 1 interrupts separately.
+        write_icc_ctlr_el1(0);
+
+        // SAFETY: We know that `self.gicd` is a valid and unique pointer to the registers of a
+        // GIC distributor interface.
+        unsafe {
+            // Enable affinity routing and non-secure group 1 interrupts.
+            (&raw mut (*self.gicd).ctlr).write_volatile(GicdCtlr::ARE_S | GicdCtlr::EnableGrp1NS);
+        }
+
+        // SAFETY: We know that `self.gicd` is a valid and unique pointer to the registers of a
+        // GIC distributor interface, and `self.sgi` to the SGI and PPI registers of a GIC
+        // redistributor interface.
+        unsafe {
+            // Put all SGIs and PPIs into non-secure group 1.
+            (&raw mut (*self.sgi).igroupr0).write_volatile(0xffffffff);
+            // Put all SPIs into non-secure group 1.
+            for i in 1..32 {
+                (&raw mut (*self.gicd).igroupr[i]).write_volatile(0xffffffff);
+            }
+        }
+
+        // Enable non-secure group 1.
+        write_icc_igrpen1_el1(0x00000001);
+    }
+
+    /// Enables or disables the interrupt with the given ID.
+    pub fn enable_interrupt(&mut self, intid: IntId, enable: bool) {
+        let index = (intid.0 / 32) as usize;
+        let bit = 1 << (intid.0 % 32);
+
+        // SAFETY: We know that `self.gicd` is a valid and unique pointer to the registers of a
+        // GIC distributor interface, and `self.sgi` to the SGI and PPI registers of a GIC
+        // redistributor interface.
+        unsafe {
+            if enable {
+                (&raw mut (*self.gicd).isenabler[index]).write_volatile(bit);
+                if intid.is_private() {
+                    (&raw mut (*self.sgi).isenabler0).write_volatile(bit);
+                }
+            } else {
+                (&raw mut (*self.gicd).icenabler[index]).write_volatile(bit);
+                if intid.is_private() {
+                    (&raw mut (*self.sgi).icenabler0).write_volatile(bit);
+                }
+            }
+        }
+    }
+
+    /// Enables all interrupts.
+    pub fn enable_all_interrupts(&mut self, enable: bool) {
+        for i in 0..32 {
+            // SAFETY: We know that `self.gicd` is a valid and unique pointer to the registers
+            // of a GIC distributor interface.
+            unsafe {
+                if enable {
+                    (&raw mut (*self.gicd).isenabler[i]).write_volatile(0xffffffff);
+                } else {
+                    (&raw mut (*self.gicd).icenabler[i]).write_volatile(0xffffffff);
+                }
+            }
+        }
+        // SAFETY: We know that `self.sgi` is a valid and unique pointer to the SGI and PPI
+        // registers of a GIC redistributor interface.
+        unsafe {
+            if enable {
+                (&raw mut (*self.sgi).isenabler0).write_volatile(0xffffffff);
+            } else {
+                (&raw mut (*self.sgi).icenabler0).write_volatile(0xffffffff);
+            }
+        }
+    }
+
+    /// Sets the priority mask for the current CPU core.
+    ///
+    /// Only interrupts with a higher priority (numerically lower) will be signalled.
+    pub fn set_priority_mask(min_priority: u8) {
+        write_icc_pmr_el1(min_priority.into());
+    }
+
+    /// Sets the priority of the interrupt with the given ID.
+    ///
+    /// Note that lower numbers correspond to higher priorities; i.e. 0 is the highest priority, and
+    /// 255 is the lowest.
+    pub fn set_interrupt_priority(&mut self, intid: IntId, priority: u8) {
+        // SAFETY: We know that `self.gicd` is a valid and unique pointer to the registers of a
+        // GIC distributor interface, and `self.sgi` to the SGI and PPI registers of a GIC
+        // redistributor interface.
+        unsafe {
+            // Affinity routing is enabled, so use the GICR for SGIs and PPIs.
+            if intid.is_private() {
+                (&raw mut (*self.sgi).ipriorityr[intid.0 as usize]).write_volatile(priority);
+            } else {
+                (&raw mut (*self.gicd).ipriorityr[intid.0 as usize]).write_volatile(priority);
+            }
+        }
+    }
+
+    /// Configures the trigger type for the interrupt with the given ID.
+    pub fn set_trigger(&mut self, intid: IntId, trigger: Trigger) {
+        let index = (intid.0 / 16) as usize;
+        let bit = 1 << (((intid.0 % 16) * 2) + 1);
+
+        // SAFETY: We know that `self.gicd` is a valid and unique pointer to the registers of a
+        // GIC distributor interface, and `self.sgi` to the SGI and PPI registers of a GIC
+        // redistributor interface.
+        unsafe {
+            // Affinity routing is enabled, so use the GICR for SGIs and PPIs.
+            let register = if intid.is_private() {
+                (&raw mut (*self.sgi).icfgr[index])
+            } else {
+                (&raw mut (*self.gicd).icfgr[index])
+            };
+            let v = register.read_volatile();
+            register.write_volatile(match trigger {
+                Trigger::Edge => v | bit,
+                Trigger::Level => v & !bit,
+            });
+        }
+    }
+
+    /// Assigns the interrupt with id `intid` to interrupt group `group`.
+    pub fn set_group(&mut self, intid: IntId, group: Group) {
+        // FIXME: For now we assume that we are running a single-core system.
+        // so there's just one GICR frame and one SGI configuration.
+
+        // SAFETY: We know that `self.gicd` is a valid and unique pointer to the registers of a
+        // GIC distributor interface, and `self.sgi` to the SGI and PPI registers of a GIC
+        // redistributor interface.
+        let (igroupr, igrpmodr): (*mut [u32], *mut [u32]) = unsafe {
+            if intid.is_private() {
+                (
+                    &raw mut (*self.sgi).igroupr0 as *mut [u32; 1],
+                    &raw mut (*self.sgi).igrpmodr0 as *mut [u32; 1],
+                )
+            } else {
+                (
+                    &raw mut (*self.gicd).igroupr,
+                    &raw mut (*self.gicd).igrpmodr,
+                )
+            }
+        };
+
+        // SAFETY: We know that `igroupr` and `igrpmodr` are valid and unique pointers
+        // to the registers of GIC distributor or redistributor interface.
+        unsafe {
+            if let Group::Secure(sg) = group {
+                clear_bit(igroupr, intid.0 as usize);
+                match sg {
+                    SecureIntGroup::Group1S => set_bit(igrpmodr, intid.0 as usize),
+                    SecureIntGroup::Group0 => clear_bit(igrpmodr, intid.0 as usize),
+                }
+            } else {
+                set_bit(igroupr, intid.0 as usize);
+                clear_bit(igrpmodr, intid.0 as usize);
+            }
+        }
+    }
+
+    /// Sends a software-generated interrupt (SGI) to the given cores.
+    pub fn send_sgi(intid: IntId, target: SgiTarget) {
+        assert!(intid.is_sgi());
+
+        let sgi_value = match target {
+            SgiTarget::All => {
+                let irm = 0b1;
+                (u64::from(intid.0 & 0x0f) << 24) | (irm << 40)
+            }
+            SgiTarget::List {
+                affinity3,
+                affinity2,
+                affinity1,
+                target_list,
+            } => {
+                let irm = 0b0;
+                u64::from(target_list)
+                    | (u64::from(affinity1) << 16)
+                    | (u64::from(intid.0 & 0x0f) << 24)
+                    | (u64::from(affinity2) << 32)
+                    | (irm << 40)
+                    | (u64::from(affinity3) << 48)
+            }
+        };
+
+        write_icc_sgi1r_el1(sgi_value);
+    }
+
+    /// Gets the ID of the highest priority signalled interrupt, and acknowledges it.
+    ///
+    /// Returns `None` if there is no pending interrupt of sufficient priority.
+    pub fn get_and_acknowledge_interrupt() -> Option<IntId> {
+        let intid = read_icc_iar1_el1() as u32;
+        if intid >= IntId::SPECIAL_START {
+            None
+        } else {
+            Some(IntId(intid))
+        }
+    }
+
+    /// Informs the interrupt controller that the CPU has completed processing the given interrupt.
+    /// This drops the interrupt priority and deactivates the interrupt.
+    pub fn end_interrupt(intid: IntId) {
+        write_icc_eoir1_el1(intid.0.into())
+    }
+
+    /// Returns information about what the GIC implementation supports.
+    pub fn typer(&self) -> Typer {
+        // SAFETY: We know that `self.gicd` is a valid and unique pointer to the registers of a GIC
+        // distributor interface.
+        unsafe { (&raw mut (*self.gicd).typer).read_volatile() }
+    }
+
+    /// Returns a raw pointer to the GIC distributor registers.
+    ///
+    /// This may be used to read and write the registers directly for functionality not yet
+    /// supported by this driver.
+    pub fn gicd_ptr(&mut self) -> *mut GICD {
+        self.gicd
+    }
+
+    /// Returns a raw pointer to the GIC redistributor registers.
+    ///
+    /// This may be used to read and write the registers directly for functionality not yet
+    /// supported by this driver.
+    pub fn gicr_ptr(&mut self) -> *mut GICR {
+        self.gicr
+    }
+
+    /// Returns a raw pointer to the GIC redistributor SGI and PPI registers.
+    ///
+    /// This may be used to read and write the registers directly for functionality not yet
+    /// supported by this driver.
+    pub fn sgi_ptr(&mut self) -> *mut SGI {
+        self.sgi
+    }
+
+    fn gicd_barrier(&mut self) {
+        // SAFETY: We know that `self.gicd` is a valid and unique pointer to the registers of a
+        // GIC distributor interface.
+        unsafe {
+            while (&raw const (*self.gicd).ctlr)
+                .read_volatile()
+                .contains(GicdCtlr::RWP)
+            {}
+        }
+    }
+
+    fn gicd_modify_control(&mut self, f: impl FnOnce(GicdCtlr) -> GicdCtlr) {
+        // SAFETY: We know that `self.gicd` is a valid and unique pointer to the registers of a
+        // GIC distributor interface.
+        unsafe {
+            let gicd_ctlr = (&raw mut (*self.gicd).ctlr).read_volatile();
+
+            (&raw mut (*self.gicd).ctlr).write_volatile(f(gicd_ctlr));
+        }
+
+        self.gicd_barrier();
+    }
+
+    /// Clears specified bits in GIC distributor control register.
+    pub fn gicd_clear_control(&mut self, flags: GicdCtlr) {
+        self.gicd_modify_control(|old| old - flags);
+    }
+
+    /// Sets specified bits in GIC distributor control register.
+    pub fn gicd_set_control(&mut self, flags: GicdCtlr) {
+        self.gicd_modify_control(|old| old | flags);
+    }
+
+    /// Blocks until register write for the current Security state is no longer in progress.
+    pub fn gicr_barrier(&mut self) {
+        // FIXME: For now we assume that we are running a single-core system.
+        // so there's just one GICR frame and one SGI configuration.
+
+        // SAFETY: We know that `self.sgi` is a valid and unique pointer to the SGI and PPI
+        // registers of a GIC redistributor interface.
+        unsafe {
+            while (&raw const (*self.gicr).ctlr)
+                .read_volatile()
+                .contains(GicrCtlr::RWP)
+            {}
+        }
+    }
+
+    /// Informs the GIC redistributor that the core has awakened.
+    ///
+    /// Blocks until `GICR_WAKER.ChildrenAsleep` is cleared.
+    pub fn redistributor_mark_core_awake(&mut self) -> Result<(), GICRError> {
+        // FIXME: For now we assume that we are running a single-core system.
+        // so there's just one GICR frame and one SGI configuration.
+
+        // SAFETY: We know that `self.gicr` is a valid and unique pointer to
+        // the GIC redistributor interface.
+        unsafe {
+            let mut gicr_waker = (&raw const (*self.gicr).waker).read_volatile();
+
+            // The WAKER_PS_BIT should be changed to 0 only when WAKER_CA_BIT is 1.
+            if !gicr_waker.contains(Waker::CHILDREN_ASLEEP) {
+                return Err(GICRError::AlreadyAwake);
+            }
+
+            // Mark the connected core as awake.
+            gicr_waker -= Waker::PROCESSOR_SLEEP;
+            (&raw mut (*self.gicr).waker).write_volatile(gicr_waker);
+
+            // Wait till the WAKER_CA_BIT changes to 0.
+            while (&raw const (*self.gicr).waker)
+                .read_volatile()
+                .contains(Waker::CHILDREN_ASLEEP)
+            {
+                spin_loop();
+            }
+
+            Ok(())
+        }
+    }
+}
+
+// SAFETY: The GIC interface can be accessed from any CPU core.
+unsafe impl Send for GicV3 {}
+
+// SAFETY: Any operations which change state require `&mut GicV3`, so `&GicV3` is fine to share.
+unsafe impl Sync for GicV3 {}
+
+/// The group configuration for an interrupt.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum Group {
+    Secure(SecureIntGroup),
+    Group1NS,
+}
+
+/// The group configuration for an interrupt.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum SecureIntGroup {
+    /// The interrupt belongs to Secure Group 1.
+    Group1S,
+    /// The interrupt belongs to Group 0.
+    Group0,
+}
+
+/// The target specification for a software-generated interrupt.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum SgiTarget {
+    /// The SGI is routed to all CPU cores except the current one.
+    All,
+    /// The SGI is routed to the CPU cores matching the given affinities and list.
+    List {
+        affinity3: u8,
+        affinity2: u8,
+        affinity1: u8,
+        target_list: u16,
+    },
+}

--- a/arm-gic/src/gicv3/registers.rs
+++ b/arm-gic/src/gicv3/registers.rs
@@ -1,0 +1,406 @@
+// Copyright 2023 The arm-gic Authors.
+// This project is dual-licensed under Apache 2.0 and MIT terms.
+// See LICENSE-APACHE and LICENSE-MIT for details.
+
+//! Raw register access for the GICv3.
+
+use super::IntId;
+use bitflags::bitflags;
+use core::cmp::min;
+
+bitflags! {
+    #[repr(transparent)]
+    #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+    pub struct GicdCtlr: u32 {
+        const RWP = 1 << 31;
+        const nASSGIreq = 1 << 8;
+        const E1NWF = 1 << 7;
+        const DS = 1 << 6;
+        const ARE_NS = 1 << 5;
+        const ARE_S = 1 << 4;
+        const EnableGrp1S = 1 << 2;
+        const EnableGrp1NS = 1 << 1;
+        const EnableGrp0 = 1 << 0;
+    }
+}
+
+bitflags! {
+    #[repr(transparent)]
+    #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+    pub struct GicrCtlr: u32 {
+        const UWP = 1 << 31;
+        const DPG1S = 1 << 26;
+        const DPG1NS = 1 << 25;
+        const DPG0 = 1 << 24;
+        const RWP = 1 << 3;
+        const IR = 1 << 2;
+        const CES = 1 << 1;
+        const EnableLPIs = 1 << 0;
+    }
+}
+
+/// Interrupt controller type register value.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(transparent)]
+pub struct Typer(u32);
+
+impl Typer {
+    /// Returns the value of the ESPI_range field.
+    fn espi_range(self) -> u32 {
+        self.0 >> 27
+    }
+
+    /// Returns the highest supported Extended SPI interrupt ID.
+    pub fn max_espi(self) -> IntId {
+        IntId::espi(32 * self.espi_range() + 31)
+    }
+
+    /// Returns the range of affinity level 0 values supported for targeted SGIs.
+    pub fn range_selector_support(self) -> RangeSelectorSupport {
+        if self.0 & (1 << 26) == 0 {
+            RangeSelectorSupport::AffZero16
+        } else {
+            RangeSelectorSupport::AffZero256
+        }
+    }
+
+    /// Returns whether 1 of N SPI interrupts are supported.
+    pub fn one_of_n_supported(self) -> bool {
+        self.0 & (1 << 25) == 0
+    }
+
+    /// Returns whether the GICD supports nonzero values for affinity level 3.
+    pub fn affinity_3_supported(self) -> bool {
+        self.0 & (1 << 24) != 0
+    }
+
+    /// Returns the number of interrupt ID bits supported.
+    pub fn id_bits(self) -> u32 {
+        ((self.0 >> 19) & 0b11111) + 1
+    }
+
+    /// Returns whether Direct Virtual LPI injection is supported.
+    pub fn dvi_supported(self) -> bool {
+        self.0 & (1 << 18) != 0
+    }
+
+    /// Returns whether LPIs are supported.
+    pub fn lpis_supported(self) -> bool {
+        self.0 & (1 << 17) != 0
+    }
+
+    /// Returns whether message-based interrupts are supported.
+    pub fn mpis_supported(self) -> bool {
+        self.0 & (1 << 16) != 0
+    }
+
+    /// Returns the number of LPIs supported.
+    pub fn num_lpis(self) -> u32 {
+        let num_lpis = (self.0 >> 11) & 0b11111;
+        if num_lpis == 0 {
+            (1u32 << self.id_bits()).saturating_sub(8192)
+        } else {
+            2 << num_lpis
+        }
+    }
+
+    /// Returns whether the GIC supports two security states.
+    pub fn has_security_extension(self) -> bool {
+        self.0 & (1 << 10) != 0
+    }
+
+    /// Returns whether the non-maskable interrupt property is supported.
+    pub fn nmi_supported(self) -> bool {
+        self.0 & (1 << 9) != 0
+    }
+
+    /// Returns whether the extended SPI range is implemented.
+    pub fn espi_supported(self) -> bool {
+        self.0 & (1 << 8) != 0
+    }
+
+    /// Returns the number of CPU cores supported when affinity routing is disabled.
+    pub fn num_cpus(self) -> u32 {
+        (self.0 >> 5) & 0b111
+    }
+
+    /// Returns the number of SPIs supported.
+    pub fn num_spis(self) -> u32 {
+        let it_lines = self.0 & 0b11111;
+        min(32 * it_lines, IntId::MAX_SPI_COUNT)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RangeSelectorSupport {
+    /// The IRI supports targeted SGIs with affinity level 0 values up to 15.
+    AffZero16,
+    /// The IRI supports targeted SGIs with affinity level 0 values up to 255.
+    AffZero256,
+}
+
+/// GIC Distributor registers.
+#[allow(clippy::upper_case_acronyms)]
+#[repr(C, align(8))]
+pub struct GICD {
+    /// Distributor control register.
+    pub ctlr: GicdCtlr,
+    /// Interrupt controller type register.
+    pub typer: Typer,
+    /// Distributor implementer identification register.
+    pub iidr: u32,
+    /// Interrupt controller type register 2.
+    pub typer2: u32,
+    /// Error reporting status register.
+    pub statusr: u32,
+    _reserved0: [u32; 3],
+    /// Implementation defined registers.
+    pub implementation_defined: [u32; 8],
+    /// Set SPI register.
+    pub setspi_nsr: u32,
+    _reserved1: u32,
+    /// Clear SPI register.
+    pub clrspi_nsr: u32,
+    _reserved2: u32,
+    /// Set SPI secure register.
+    pub setspi_sr: u32,
+    _reserved3: u32,
+    /// Clear SPI secure register.
+    pub clrspi_sr: u32,
+    _reserved4: [u32; 9],
+    /// Interrupt group registers.
+    pub igroupr: [u32; 32],
+    /// Interrupt set-enable registers.
+    pub isenabler: [u32; 32],
+    /// Interrupt clear-enable registers.
+    pub icenabler: [u32; 32],
+    /// Interrupt set-pending registers.
+    pub ispendr: [u32; 32],
+    /// Interrupt clear-pending registers.
+    pub icpendr: [u32; 32],
+    /// Interrupt set-active registers.
+    pub isactiver: [u32; 32],
+    /// Interrupt clear-active registers.
+    pub icactiver: [u32; 32],
+    /// Interrupt priority registers.
+    pub ipriorityr: [u8; 1024],
+    /// Interrupt processor targets registers.
+    pub itargetsr: [u32; 256],
+    /// Interrupt configuration registers.
+    pub icfgr: [u32; 64],
+    /// Interrupt group modifier registers.
+    pub igrpmodr: [u32; 32],
+    _reserved5: [u32; 32],
+    /// Non-secure access control registers.
+    pub nsacr: [u32; 64],
+    /// Software generated interrupt register.
+    pub sigr: u32,
+    _reserved6: [u32; 3],
+    /// SGI clear-pending registers.
+    pub cpendsgir: [u32; 4],
+    /// SGI set-pending registers.
+    pub spendsgir: [u32; 4],
+    _reserved7: [u32; 20],
+    /// Non-maskable interrupt registers.
+    pub inmir: [u32; 32],
+    /// Interrupt group registers for extended SPI range.
+    pub igroupr_e: [u32; 32],
+    _reserved8: [u32; 96],
+    /// Interrupt set-enable registers for extended SPI range.
+    pub isenabler_e: [u32; 32],
+    _reserved9: [u32; 96],
+    /// Interrupt clear-enable registers for extended SPI range.
+    pub icenabler_e: [u32; 32],
+    _reserved10: [u32; 96],
+    /// Interrupt set-pending registers for extended SPI range.
+    pub ispendr_e: [u32; 32],
+    _reserved11: [u32; 96],
+    /// Interrupt clear-pending registers for extended SPI range.
+    pub icpendr_e: [u32; 32],
+    _reserved12: [u32; 96],
+    /// Interrupt set-active registers for extended SPI range.
+    pub isactive_e: [u32; 32],
+    _reserved13: [u32; 96],
+    /// Interrupt clear-active registers for extended SPI range.
+    pub icactive_e: [u32; 32],
+    _reserved14: [u32; 224],
+    /// Interrupt priority registers for extended SPI range.
+    pub ipriorityr_e: [u8; 1024],
+    _reserved15: [u32; 768],
+    /// Extended SPI configuration registers.
+    pub icfgr_e: [u32; 64],
+    _reserved16: [u32; 192],
+    /// Interrupt group modifier registers for extended SPI range.
+    pub igrpmodr_e: [u32; 32],
+    _reserved17: [u32; 96],
+    /// Non-secure access control registers for extended SPI range.
+    pub nsacr_e: [u32; 32],
+    _reserved18: [u32; 288],
+    /// Non-maskable interrupt registers for extended SPI range.
+    pub inmr_e: [u32; 32],
+    _reserved19: [u32; 2400],
+    /// Interrupt routing registers.
+    pub irouter: [u64; 988],
+    _reserved20: [u32; 8],
+    /// Interrupt routing registers for extended SPI range.
+    pub irouter_e: [u64; 1024],
+    _reserved21: [u32; 2048],
+    /// Implementation defined registers.
+    pub implementation_defined2: [u32; 4084],
+    /// ID registers.
+    pub id_registers: [u32; 12],
+}
+
+bitflags! {
+    #[repr(transparent)]
+    #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+    pub struct Waker: u32 {
+        const CHILDREN_ASLEEP = 1 << 2;
+        const PROCESSOR_SLEEP = 1 << 1;
+    }
+}
+
+/// GIC Redistributor registers.
+#[allow(clippy::upper_case_acronyms)]
+#[repr(C, align(8))]
+pub struct GICR {
+    /// Redistributor control register.
+    pub ctlr: GicrCtlr,
+    /// Implementer identification register.
+    pub iidr: u32,
+    /// Redistributor type register.
+    pub typer: u64,
+    /// Error reporting status register.
+    pub statusr: u32,
+    /// Redistributor wake register.
+    pub waker: Waker,
+    /// Report maximum PARTID and PMG register.
+    pub mpamidr: u32,
+    /// Set PARTID and PMG register.
+    pub partidr: u32,
+    /// Implementation defined registers.
+    pub implementation_defined1: [u32; 8],
+    /// Set LPI pending register.
+    pub setlprir: u64,
+    /// Clear LPI pending register.
+    pub clrlpir: u64,
+    _reserved0: [u32; 8],
+    /// Redistributor properties base address register.
+    pub propbaser: u64,
+    /// Redistributor LPI pending table base address register.
+    pub pendbaser: u64,
+    _reserved1: [u32; 8],
+    /// Redistributor invalidate LPI register.
+    pub invlpir: u64,
+    _reserved2: u64,
+    /// Redistributor invalidate all register.
+    pub invallr: u64,
+    _reserved3: u64,
+    /// Redistributor synchronize register.
+    pub syncr: u32,
+    _reserved4: [u32; 15],
+    /// Implementation defined registers.
+    pub implementation_defined2: u64,
+    _reserved5: u64,
+    /// Implementation defined registers.
+    pub implementation_defined3: u64,
+    _reserved6: [u32; 12218],
+    /// Implementation defined registers.
+    pub implementation_defined4: [u32; 4084],
+    /// ID registers.
+    pub id_registers: [u32; 12],
+}
+
+/// GIC Redistributor SGI and PPI registers.
+#[allow(clippy::upper_case_acronyms)]
+#[repr(C, align(8))]
+pub struct SGI {
+    _reserved0: [u32; 32],
+    /// Interrupt group register 0.
+    pub igroupr0: u32,
+    /// Interrupt group registers for extended PPI range.
+    pub igroupr_e: [u32; 2],
+    _reserved1: [u32; 29],
+    /// Interrupt set-enable register 0.
+    pub isenabler0: u32,
+    /// Interrupt set-enable registers for extended PPI range.
+    pub isenabler_e: [u32; 2],
+    _reserved2: [u32; 29],
+    /// Interrupt clear-enable register 0.
+    pub icenabler0: u32,
+    /// Interrupt clear-enable registers for extended PPI range.
+    pub icenabler_e: [u32; 2],
+    _reserved3: [u32; 29],
+    /// Interrupt set-pending register 0.
+    pub ispendr0: u32,
+    /// Interrupt set-pending registers for extended PPI range.
+    pub ispendr_e: [u32; 2],
+    _reserved4: [u32; 29],
+    /// Interrupt clear-pending register 0.
+    pub icpendr0: u32,
+    /// Interrupt clear-pending registers for extended PPI range.
+    pub icpendr_e: [u32; 2],
+    _reserved5: [u32; 29],
+    /// Interrupt set-active register 0.
+    pub isactiver0: u32,
+    /// Interrupt set-active registers for extended PPI range.
+    pub isactive_e: [u32; 2],
+    _reserved6: [u32; 29],
+    /// Interrupt clear-active register 0.
+    pub icactiver0: u32,
+    /// Interrupt clear-active registers for extended PPI range.
+    pub icactive_e: [u32; 2],
+    _reserved7: [u32; 29],
+    /// Interrupt priority registers.
+    pub ipriorityr: [u8; 32],
+    /// Interrupt priority registers for extended PPI range.
+    pub ipriorityr_e: [u8; 64],
+    _reserved8: [u32; 488],
+    /// SGI configuration register, PPI configuration register and extended PPI configuration
+    /// registers.
+    pub icfgr: [u32; 6],
+    _reserved9: [u32; 58],
+    /// Interrupt group modifier register 0.
+    pub igrpmodr0: u32,
+    /// Interrupt group modifier registers for extended PPI range.
+    pub igrpmodr_e: [u32; 2],
+    _reserved10: [u32; 61],
+    /// Non-secure access control register.
+    pub nsacr: u32,
+    _reserved11: [u32; 95],
+    /// Non-maskable interrupt register for PPIs.
+    pub inmir0: u32,
+    /// Non-maskable interrupt register for extended PPIs.
+    pub inmir_e: [u32; 31],
+    _reserved12: [u32; 11264],
+    /// Implementation defined registers.
+    pub implementation_defined: [u32; 4084],
+    _reserved13: [u32; 12],
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn max_espi() {
+        assert_eq!(Typer(0xffffffff).max_espi().0, IntId::ESPI_END - 1);
+    }
+
+    #[test]
+    fn num_lpis() {
+        // num_LPIs is 0, no IDbits means no LPIs.
+        assert_eq!(Typer(0).num_lpis(), 0);
+        // num_LPIs is 0, 13 IDbits means no LPIs.
+        assert_eq!(Typer(12 << 19).num_lpis(), 0);
+        // num_LPIs is 0, 14 IDbits means 2**13 LPIs.
+        assert_eq!(Typer(13 << 19).num_lpis(), 1 << 13);
+        // num_LPIs is 0, 15 IDbits means 2**13 LPIs.
+        assert_eq!(Typer(13 << 19).num_lpis(), 1 << 13);
+
+        // num_LPIs is specified.
+        assert_eq!(Typer(1 << 11).num_lpis(), 4);
+        assert_eq!(Typer(2 << 11).num_lpis(), 8);
+        assert_eq!(Typer(16 << 11).num_lpis(), 1 << 17);
+    }
+}

--- a/arm-gic/src/lib.rs
+++ b/arm-gic/src/lib.rs
@@ -1,0 +1,256 @@
+// Copyright 2023 The arm-gic Authors.
+// This project is dual-licensed under Apache 2.0 and MIT terms.
+// See LICENSE-APACHE and LICENSE-MIT for details.
+
+//! Driver for the Arm Generic Interrupt Controller version 2, 3 or 4, on aarch64.
+//!
+//! This top level module contains functions that are not specific to any particular interrupt
+//! controller, as support for other GIC versions may be added in future.
+//!
+//! # Example
+//!
+//! ```
+//! use arm_gic::{
+//!     gicv3::{GicV3, IntId, SgiTarget},
+//!     irq_enable,
+//! };
+//!
+//! // Base addresses of the GICv3 distributor and redistributor.
+//! const GICD_BASE_ADDRESS: *mut u64 = 0x800_0000 as _;
+//! const GICR_BASE_ADDRESS: *mut u64 = 0x80A_0000 as _;
+//!
+//! // Initialise the GIC.
+//! let mut gic = unsafe { GicV3::new(GICD_BASE_ADDRESS, GICR_BASE_ADDRESS) };
+//! gic.setup();
+//!
+//! // Configure an SGI and then send it to ourself.
+//! let sgi_intid = IntId::sgi(3);
+//! GicV3::set_priority_mask(0xff);
+//! gic.set_interrupt_priority(sgi_intid, 0x80);
+//! gic.enable_interrupt(sgi_intid, true);
+//! irq_enable();
+//! GicV3::send_sgi(
+//!     sgi_intid,
+//!     SgiTarget::List {
+//!         affinity3: 0,
+//!         affinity2: 0,
+//!         affinity1: 0,
+//!         target_list: 0b1,
+//!     },
+//! );
+//! ```
+
+#![cfg_attr(not(test), no_std)]
+#![deny(clippy::undocumented_unsafe_blocks)]
+
+pub mod gicv2;
+pub mod gicv3;
+mod sysreg;
+
+#[cfg(target_arch = "aarch64")]
+use core::arch::asm;
+use core::fmt::{Debug, Formatter, Result};
+
+/// The trigger configuration for an interrupt.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum Trigger {
+    /// The interrupt is edge triggered.
+    Edge,
+    /// The interrupt is level triggered.
+    Level,
+}
+
+/// An interrupt ID.
+#[derive(Copy, Clone, Eq, Ord, PartialOrd, PartialEq)]
+pub struct IntId(u32);
+
+impl IntId {
+    /// Special interrupt ID returned when running at EL3 and the interrupt should be handled at
+    /// S-EL2 or S-EL1.
+    pub const SPECIAL_SECURE: Self = Self(1020);
+
+    /// Special interrupt ID returned when running at EL3 and the interrupt should be handled at
+    /// (non-secure) EL2 or EL1.
+    pub const SPECIAL_NONSECURE: Self = Self(1021);
+
+    /// Special interrupt ID returned when the interrupt is a non-maskable interrupt.
+    pub const SPECIAL_NMI: Self = Self(1022);
+
+    /// Special interrupt ID returned when there is no pending interrupt of sufficient priority for
+    /// the current security state and interrupt group.
+    pub const SPECIAL_NONE: Self = Self(1023);
+
+    /// The maximum number of SPIs which may be supported.
+    pub const MAX_SPI_COUNT: u32 = Self::SPECIAL_START - Self::SPI_START;
+
+    /// The number of Software Generated Interrupts.
+    pub const SGI_COUNT: u32 = Self::PPI_START - Self::SGI_START;
+
+    /// The number of (non-extended) Private Peripheral Interrupts.
+    pub const PPI_COUNT: u32 = Self::SPI_START - Self::PPI_START;
+
+    /// The maximum number of extended Private Peripheral Interrupts which may be supported.
+    pub const MAX_EPPI_COUNT: u32 = Self::EPPI_END - Self::EPPI_START;
+
+    /// The maximum number of extended Shared Peripheral Interrupts which may be supported.
+    pub const MAX_ESPI_COUNT: u32 = Self::ESPI_END - Self::ESPI_START;
+
+    /// The ID of the first Software Generated Interrupt.
+    const SGI_START: u32 = 0;
+
+    /// The ID of the first Private Peripheral Interrupt.
+    const PPI_START: u32 = 16;
+
+    /// The ID of the first Shared Peripheral Interrupt.
+    const SPI_START: u32 = 32;
+
+    /// The first special interrupt ID.
+    const SPECIAL_START: u32 = 1020;
+
+    /// One more than the last special interrupt ID.
+    const SPECIAL_END: u32 = 1024;
+
+    /// The first extended Private Peripheral Interrupt.
+    const EPPI_START: u32 = 1056;
+
+    /// One more than the last extended Private Peripheral Interrupt.
+    const EPPI_END: u32 = 1120;
+
+    /// The first extended Shared Peripheral Interrupt.
+    const ESPI_START: u32 = 4096;
+
+    /// One more than the last extended Shared Peripheral Interrupt.
+    const ESPI_END: u32 = 5120;
+
+    /// The first Locality-specific Peripheral Interrupt.
+    const LPI_START: u32 = 8192;
+
+    /// Returns the interrupt ID for the given Software Generated Interrupt.
+    pub const fn sgi(sgi: u32) -> Self {
+        assert!(sgi < Self::SGI_COUNT);
+        Self(Self::SGI_START + sgi)
+    }
+
+    /// Returns the interrupt ID for the given Private Peripheral Interrupt.
+    pub const fn ppi(ppi: u32) -> Self {
+        assert!(ppi < Self::PPI_COUNT);
+        Self(Self::PPI_START + ppi)
+    }
+
+    /// Returns the interrupt ID for the given Shared Peripheral Interrupt.
+    pub const fn spi(spi: u32) -> Self {
+        assert!(spi < Self::MAX_SPI_COUNT);
+        Self(Self::SPI_START + spi)
+    }
+
+    /// Returns the interrupt ID for the given extended Private Peripheral Interrupt.
+    pub const fn eppi(eppi: u32) -> Self {
+        assert!(eppi < Self::MAX_EPPI_COUNT);
+        Self(Self::EPPI_START + eppi)
+    }
+
+    /// Returns the interrupt ID for the given extended Shared Peripheral Interrupt.
+    pub const fn espi(espi: u32) -> Self {
+        assert!(espi < Self::MAX_ESPI_COUNT);
+        Self(Self::ESPI_START + espi)
+    }
+
+    /// Returns the interrupt ID for the given Locality-specific Peripheral Interrupt.
+    pub const fn lpi(lpi: u32) -> Self {
+        Self(Self::LPI_START + lpi)
+    }
+
+    /// Returns whether this interrupt ID is for a Software Generated Interrupt.
+    fn is_sgi(self) -> bool {
+        self.0 < Self::PPI_START
+    }
+
+    /// Returns whether this interrupt ID is for a Private Peripheral Interrupt.
+    pub fn is_ppi(self) -> bool {
+        Self::PPI_START <= self.0 && self.0 < Self::SPI_START
+    }
+
+    /// Returns whether this interrupt ID is private to a core, i.e. it is an SGI or PPI.
+    pub fn is_private(self) -> bool {
+        self.is_sgi() || self.is_ppi()
+    }
+
+    /// Returns whether this interrupt ID is for a Shared Peripheral Interrupt.
+    pub fn is_spi(self) -> bool {
+        Self::SPI_START <= self.0 && self.0 < Self::SPECIAL_START
+    }
+
+    // TODO: Change this to return a Range<IntId> once core::iter::Step is stabilised.
+    /// Returns an array of all interrupt Ids that are private to a core, i.e. SGIs and PPIs.
+    pub fn private() -> impl Iterator<Item = IntId> {
+        let sgis = (0..Self::SGI_COUNT).map(Self::sgi);
+        let ppis = (0..Self::PPI_COUNT).map(Self::ppi);
+
+        sgis.chain(ppis)
+    }
+
+    // TODO: Change this to return a Range<IntId> once core::iter::Step is stabilised.
+    /// Returns an array of all SPI Ids.
+    pub fn spis() -> impl Iterator<Item = IntId> {
+        (0..Self::MAX_SPI_COUNT).map(Self::spi)
+    }
+}
+
+impl Debug for IntId {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        if self.0 < Self::PPI_START {
+            write!(f, "SGI {}", self.0 - Self::SGI_START)
+        } else if self.0 < Self::SPI_START {
+            write!(f, "PPI {}", self.0 - Self::PPI_START)
+        } else if self.0 < Self::SPECIAL_START {
+            write!(f, "SPI {}", self.0 - Self::SPI_START)
+        } else if self.0 < Self::SPECIAL_END {
+            write!(f, "Special IntId {}", self.0)
+        } else if self.0 < Self::EPPI_START {
+            write!(f, "Reserved IntId {}", self.0)
+        } else if self.0 < Self::EPPI_END {
+            write!(f, "EPPI {}", self.0 - Self::EPPI_START)
+        } else if self.0 < Self::ESPI_START {
+            write!(f, "Reserved IntId {}", self.0)
+        } else if self.0 < Self::ESPI_END {
+            write!(f, "ESPI {}", self.0 - Self::ESPI_START)
+        } else if self.0 < Self::LPI_START {
+            write!(f, "Reserved IntId {}", self.0)
+        } else {
+            write!(f, "LPI {}", self.0 - Self::LPI_START)
+        }
+    }
+}
+
+impl From<IntId> for u32 {
+    fn from(intid: IntId) -> Self {
+        intid.0
+    }
+}
+
+/// Disables debug, SError, IRQ and FIQ exceptions.
+#[cfg(target_arch = "aarch64")]
+pub fn irq_disable() {
+    // SAFETY: Writing to this system register doesn't access memory in any way.
+    unsafe {
+        asm!("msr DAIFSet, #0xf", options(nomem, nostack));
+    }
+}
+
+/// Enables debug, SError, IRQ and FIQ exceptions.
+#[cfg(target_arch = "aarch64")]
+pub fn irq_enable() {
+    // SAFETY: Writing to this system register doesn't access memory in any way.
+    unsafe {
+        asm!("msr DAIFClr, #0xf", options(nomem, nostack));
+    }
+}
+
+/// Waits for an interrupt.
+#[cfg(target_arch = "aarch64")]
+pub fn wfi() {
+    // SAFETY: This doesn't access memory in any way.
+    unsafe {
+        asm!("wfi", options(nomem, nostack));
+    }
+}

--- a/arm-gic/src/sysreg.rs
+++ b/arm-gic/src/sysreg.rs
@@ -1,0 +1,74 @@
+// Copyright 2023 The arm-gic Authors.
+// This project is dual-licensed under Apache 2.0 and MIT terms.
+// See LICENSE-APACHE and LICENSE-MIT for details.
+
+#[cfg(test)]
+#[macro_use]
+pub mod fake;
+
+#[cfg(target_arch = "arm")]
+use core::arch::asm;
+
+pub fn read_icc_iar1_el1() -> u64 {
+    let r: usize;
+    #[cfg(target_arch = "arm")]
+    // Safety: This loads from a co-processor register to a main register
+    unsafe {
+        asm!("mrc p15, 0, {}, c12, c12, 0", out(reg) r, options(nomem, nostack, preserves_flags));
+    }
+    #[cfg(not(target_arch = "arm"))]
+    {
+        r = 0;
+    }
+    r as u64
+}
+
+pub fn write_icc_ctlr_el1(_value: u64) {
+    #[cfg(target_arch = "arm")]
+    // Safety: This copies from a main register to a co-processor register
+    unsafe {
+        asm!("mcr p15, 0, {}, c12, c12, 4", in(reg) _value as u32, options(nomem, nostack, preserves_flags));
+    }
+}
+
+pub fn write_icc_eoir1_el1(_value: u64) {
+    #[cfg(target_arch = "arm")]
+    // Safety: This copies from a main register to a co-processor register
+    unsafe {
+        asm!("mcr p15, 0, {}, c12, c12, 1", in(reg) _value as u32, options(nomem, nostack, preserves_flags));
+    }
+}
+
+pub fn write_icc_igrpen1_el1(_value: u64) {
+    #[cfg(target_arch = "arm")]
+    // Safety: This copies from a main register to a co-processor register
+    unsafe {
+        asm!("mcr p15, 0, {}, c12, c12, 7", in(reg) _value as u32, options(nomem, nostack, preserves_flags));
+    }
+}
+
+pub fn write_icc_pmr_el1(_value: u64) {
+    #[cfg(target_arch = "arm")]
+    // Safety: This copies from a main register to a co-processor register
+    unsafe {
+        asm!("mcr p15, 0, {}, c4, c6, 0", in(reg) _value as u32, options(nomem, nostack, preserves_flags));
+    }
+}
+
+pub fn write_icc_sgi1r_el1(_value: u64) {
+    #[cfg(target_arch = "arm")]
+    // Safety: This copies from a main register to a co-processor register
+    unsafe {
+        let value_hi = (_value >> 32) as u32;
+        let value_lo = _value as u32;
+        asm!("mcrr p15, 0, {rt}, {rt2}, c12", rt = in(reg) value_lo, rt2 = in(reg) value_hi, options(nomem, nostack, preserves_flags));
+    }
+}
+
+pub fn write_icc_sre_el1(_value: u64) {
+    #[cfg(target_arch = "arm")]
+    // Safety: This copies from a main register to a co-processor register
+    unsafe {
+        asm!("mcr p15, 0, {}, c12, c12, 5", in(reg) _value as u32, options(nomem, nostack, preserves_flags));
+    }
+}

--- a/arm-gic/src/sysreg/fake.rs
+++ b/arm-gic/src/sysreg/fake.rs
@@ -1,0 +1,55 @@
+// Copyright 2025 The arm-gic Authors.
+// This project is dual-licensed under Apache 2.0 and MIT terms.
+// See LICENSE-APACHE and LICENSE-MIT for details.
+
+//! Fake implementations of system register getters and setters for unit tests.
+
+use std::sync::Mutex;
+
+/// Values of fake system registers.
+pub static SYSREGS: Mutex<SystemRegisters> = Mutex::new(SystemRegisters::new());
+
+/// A set of fake system registers.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SystemRegisters {
+    pub icc_iar1_el1: u64,
+    pub icc_ctlr_el1: u64,
+    pub icc_eoir1_el1: u64,
+    pub icc_igrpen1_el1: u64,
+    pub icc_pmr_el1: u64,
+    pub icc_sgi1r_el1: u64,
+    pub icc_sre_el1: u64,
+}
+
+impl SystemRegisters {
+    const fn new() -> Self {
+        Self {
+            icc_iar1_el1: 0,
+            icc_ctlr_el1: 0,
+            icc_eoir1_el1: 0,
+            icc_igrpen1_el1: 0,
+            icc_pmr_el1: 0,
+            icc_sgi1r_el1: 0,
+            icc_sre_el1: 0,
+        }
+    }
+}
+
+/// Generates a public function named `$function_name` to read the fake system register `$sysreg`.
+macro_rules! read_sysreg {
+    ($sysreg:ident, $function_name:ident) => {
+        pub fn $function_name() -> u64 {
+            crate::sysreg::fake::SYSREGS.lock().unwrap().$sysreg
+        }
+    };
+}
+
+/// Generates a public function named `$function_name` to write to the fake system register
+/// `$sysreg`.
+macro_rules! write_sysreg {
+    ($sysreg:ident, $function_name:ident) => {
+        pub fn $function_name(value: u64) {
+            crate::sysreg::fake::SYSREGS.lock().unwrap().$sysreg = value;
+        }
+    };
+}

--- a/arm-semihosting/Cargo.toml
+++ b/arm-semihosting/Cargo.toml
@@ -6,7 +6,7 @@ name = "arm-semihosting"
 description = "Semihosting support for Arm processors"
 readme = "README.md"
 repository = "https://github.com/ferrous-systems/cortex-r.git"
-rust-version = "1.76"
+rust-version = "1.82"
 version = "0.1.0"
 
 [dependencies]

--- a/arm-semihosting/README.md
+++ b/arm-semihosting/README.md
@@ -9,7 +9,7 @@ architecture profiles.
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.76.0 and up. It *might*
+This crate is guaranteed to compile on stable Rust 1.82.0 and up. It *might*
 compile with older versions but that may change in any new patch release.
 
 ## Licence

--- a/arm-semihosting/src/lib.rs
+++ b/arm-semihosting/src/lib.rs
@@ -149,11 +149,11 @@ pub unsafe fn syscall<T>(nr: usize, arg: &T) -> usize {
 #[inline(always)]
 pub unsafe fn syscall1(_nr: usize, _arg: usize) -> usize {
     if cfg!(all(target_arch = "arm", not(feature = "no-semihosting"))) {
-        let mut nr = _nr as u32;
-        let arg = _arg as u32;
+        let mut _nr = _nr as u32;
+        let _arg = _arg as u32;
         #[cfg(arm_isa = "a64")]
         unsafe {
-            core::arch::asm!("HLT 0xF000", inout("r0") nr, in("r1") arg, options(nostack, preserves_flags));
+            core::arch::asm!("HLT 0xF000", inout("r0") _nr, in("r1") _arg, options(nostack, preserves_flags));
         }
 
         #[cfg(arm_isa = "a32")]
@@ -162,9 +162,9 @@ pub unsafe fn syscall1(_nr: usize, _arg: usize) -> usize {
             // but not SVC instruction, even though both should be equivalent.
             // So prefer SVC but let the user pick HLT.
             if cfg!(feature = "use-hlt") {
-                core::arch::asm!("HLT 0xF000", inout("r0") nr, in("r1") arg, options(nostack, preserves_flags));
+                core::arch::asm!("HLT 0xF000", inout("r0") _nr, in("r1") _arg, options(nostack, preserves_flags));
             } else {
-                core::arch::asm!("SVC 0x123456", inout("r0") nr, in("r1") arg, options(nostack, preserves_flags));
+                core::arch::asm!("SVC 0x123456", inout("r0") _nr, in("r1") _arg, options(nostack, preserves_flags));
             }
         }
 
@@ -172,18 +172,18 @@ pub unsafe fn syscall1(_nr: usize, _arg: usize) -> usize {
         unsafe {
             // See note about about SVC vs HLT
             if cfg!(feature = "use-hlt") {
-                core::arch::asm!("HLT 0x3C", inout("r0") nr, in("r1") arg, options(nostack, preserves_flags));
+                core::arch::asm!("HLT 0x3C", inout("r0") _nr, in("r1") _arg, options(nostack, preserves_flags));
             } else {
-                core::arch::asm!("SVC 0xAB", inout("r0") nr, in("r1") arg, options(nostack, preserves_flags));
+                core::arch::asm!("SVC 0xAB", inout("r0") _nr, in("r1") _arg, options(nostack, preserves_flags));
             }
         }
 
         #[cfg(all(arm_isa = "t32", arm_profile = "m"))]
         unsafe {
-            core::arch::asm!("BKPT 0xAB", inout("r0") nr, in("r1") arg, options(nostack, preserves_flags));
+            core::arch::asm!("BKPT 0xAB", inout("r0") _nr, in("r1") _arg, options(nostack, preserves_flags));
         }
 
-        return nr as usize;
+        return _nr as usize;
     }
 
     0

--- a/arm-targets/Cargo.toml
+++ b/arm-targets/Cargo.toml
@@ -6,7 +6,7 @@ name = "arm-targets"
 description = "Compile-time feature detection for Arm processors"
 readme = "README.md"
 repository = "https://github.com/ferrous-systems/cortex-r.git"
-rust-version = "1.76"
+rust-version = "1.82"
 version = "0.1.0"
 
 

--- a/arm-targets/README.md
+++ b/arm-targets/README.md
@@ -29,7 +29,7 @@ This allows you to write Rust code in your firmware like:
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.76.0 and up. It *might*
+This crate is guaranteed to compile on stable Rust 1.82.0 and up. It *might*
 compile with older versions but that may change in any new patch release.
 
 ## Licence

--- a/arm-targets/README.md
+++ b/arm-targets/README.md
@@ -19,10 +19,6 @@ cargo:rustc-cfg=arm_architecture="v7-r"
 cargo:rustc-check-cfg=cfg(arm_architecture, values("v6-m", "v7-m", "v7e-m", "v8-m.base", "v8-m.main", "v7-r", "v8-r", "v7-a", "v8-a"))
 cargo:rustc-cfg=arm_isa="A32"
 cargo:rustc-check-cfg=cfg(arm_isa, values("A64", "A32", "T32"))
-cargo:rustc-cfg=arm_endianness="little"
-cargo:rustc-check-cfg=cfg(arm_endianness, values("little", "big"))
-cargo:rustc-cfg=arm_float_abi="hard"
-cargo:rustc-check-cfg=cfg(arm_float_abi, values("soft", "hard"))
 ```
 
 This allows you to write Rust code in your firmware like:

--- a/arm-targets/src/lib.rs
+++ b/arm-targets/src/lib.rs
@@ -35,21 +35,6 @@ pub fn process_target(target: &str) {
         r#"cargo:rustc-check-cfg=cfg(arm_profile, values({}))"#,
         Profile::values()
     );
-
-    let endianness = Endianness::get(target);
-    println!(r#"cargo:rustc-cfg=arm_endianness="{}""#, endianness);
-    println!(
-        r#"cargo:rustc-check-cfg=cfg(arm_endianness, values({}))"#,
-        Endianness::values()
-    );
-
-    if let Some(float_abi) = FloatAbi::get(target) {
-        println!(r#"cargo:rustc-cfg=arm_float_abi="{}""#, float_abi);
-    }
-    println!(
-        r#"cargo:rustc-check-cfg=cfg(arm_float_abi, values({}))"#,
-        FloatAbi::values()
-    );
 }
 
 /// The Arm Instruction Set
@@ -238,93 +223,6 @@ impl core::fmt::Display for Profile {
                 Profile::M => "m",
                 Profile::R => "r",
                 Profile::A => "a",
-            }
-        )
-    }
-}
-
-/// How does the processor handle multi-byte values
-pub enum Endianness {
-    /// The least-significant byte goes in the lowest numbered address
-    Little,
-    /// The most-significant byte goes in the lowest numbered address
-    Big,
-}
-
-impl Endianness {
-    /// Decode a target string
-    ///
-    /// We check for the known big-endian targets and assume anything else is
-    /// little-endian.
-    pub fn get(target: &str) -> Endianness {
-        if target.starts_with("aarch64be") || target.starts_with("armeb") {
-            Endianness::Big
-        } else {
-            Endianness::Little
-        }
-    }
-
-    /// Get a comma-separated list of values, suitable for cfg-check
-    pub fn values() -> String {
-        let string_versions: Vec<String> = [Endianness::Little, Endianness::Big]
-            .iter()
-            .map(|i| format!(r#""{i}""#))
-            .collect();
-        string_versions.join(", ")
-    }
-}
-
-impl core::fmt::Display for Endianness {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                Endianness::Little => "little",
-                Endianness::Big => "big",
-            }
-        )
-    }
-}
-
-/// How are floating point values passed to functions?
-pub enum FloatAbi {
-    /// Floats are passed using integer registers
-    Soft,
-    /// Floats are passed using FPU registers
-    Hard,
-}
-
-impl FloatAbi {
-    /// Decode a target string
-    pub fn get(target: &str) -> Option<FloatAbi> {
-        if target.ends_with("-eabi") {
-            Some(FloatAbi::Soft)
-        } else if target.ends_with("-eabihf") {
-            Some(FloatAbi::Hard)
-        } else {
-            None
-        }
-    }
-
-    /// Get a comma-separated list of values, suitable for cfg-check
-    pub fn values() -> String {
-        let string_versions: Vec<String> = [FloatAbi::Soft, FloatAbi::Hard]
-            .iter()
-            .map(|i| format!(r#""{i}""#))
-            .collect();
-        string_versions.join(", ")
-    }
-}
-
-impl core::fmt::Display for FloatAbi {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                FloatAbi::Soft => "soft",
-                FloatAbi::Hard => "hard",
             }
         )
     }

--- a/cortex-r-examples/.cargo/config.toml
+++ b/cortex-r-examples/.cargo/config.toml
@@ -6,7 +6,8 @@ runner = "qemu-system-arm -machine mps3-an536 -cpu cortex-r52 -semihosting -nogr
 runner = "qemu-system-arm -machine versatileab -cpu cortex-r5f -semihosting -nographic -kernel"
 
 [target.armv7r-none-eabi]
-# change to cortex-r5f if you use eabi-fpu feature
+# change to '-mcpu=cortex-r5' to '-mcpu=cortex-r5f' if you use eabi-fpu feature, otherwise
+# qemu-system-arm will lock up
 runner = "qemu-system-arm -machine versatileab -cpu cortex-r5 -semihosting -nographic -kernel"
 
 [build]

--- a/cortex-r-examples/Cargo.toml
+++ b/cortex-r-examples/Cargo.toml
@@ -8,6 +8,7 @@ readme = "README.md"
 repository = "https://github.com/ferrous-systems/cortex-r.git"
 rust-version = "1.76"
 version = "0.1.0"
+default-run = "hello"
 
 [dependencies]
 cortex-r = { path = "../cortex-r", features=["critical-section-single-core"] }

--- a/cortex-r-examples/Cargo.toml
+++ b/cortex-r-examples/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = "1.76"
 version = "0.1.0"
 
 [dependencies]
-cortex-r = { path = "../cortex-r" }
+cortex-r = { path = "../cortex-r", features=["critical-section-single-core"] }
 cortex-r-rt = { path = "../cortex-r-rt" }
 arm-semihosting = { path = "../arm-semihosting" }
 

--- a/cortex-r-examples/Cargo.toml
+++ b/cortex-r-examples/Cargo.toml
@@ -14,6 +14,12 @@ default-run = "hello"
 cortex-r = { path = "../cortex-r", features=["critical-section-single-core"] }
 cortex-r-rt = { path = "../cortex-r-rt" }
 arm-semihosting = { path = "../arm-semihosting" }
+arm-gic = { path = "../arm-gic", optional = true }
 
 [features]
 eabi-fpu = ["cortex-r-rt/eabi-fpu"]
+gic = ["arm-gic"]
+
+[[bin]]
+name = "gic"
+required-features = ["gic"]

--- a/cortex-r-examples/Cargo.toml
+++ b/cortex-r-examples/Cargo.toml
@@ -6,7 +6,7 @@ name = "cortex-r-examples"
 description = "Examples for Arm Cortex-R"
 readme = "README.md"
 repository = "https://github.com/ferrous-systems/cortex-r.git"
-rust-version = "1.76"
+rust-version = "1.82"
 version = "0.1.0"
 default-run = "hello"
 

--- a/cortex-r-examples/README.md
+++ b/cortex-r-examples/README.md
@@ -2,7 +2,7 @@
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.76.0 and up. It *might*
+This crate is guaranteed to compile on stable Rust 1.82.0 and up. It *might*
 compile with older versions but that may change in any new patch release.
 
 ## Licence

--- a/cortex-r-examples/build.rs
+++ b/cortex-r-examples/build.rs
@@ -9,12 +9,14 @@ use std::io::Write;
 fn main() {
     match std::env::var("TARGET").expect("TARGET not set").as_str() {
         "armv8r-none-eabihf" => {
-            write("mps3-an536.ld", include_bytes!("mps3-an536.ld"));
+            write("memory.x", include_bytes!("mps3-an536.ld"));
         }
         _ => {
-            write("versatileab.ld", include_bytes!("versatileab.ld"));
+            write("memory.x", include_bytes!("versatileab.ld"));
         }
     }
+    // Use the cortex-m-rt linker script
+    println!("cargo:rustc-link-arg=-Tlink.x");
 }
 
 fn write(file: &str, contents: &[u8]) {
@@ -27,5 +29,4 @@ fn write(file: &str, contents: &[u8]) {
         .unwrap();
     println!("cargo:rustc-link-search={}", out.display());
     println!("cargo:rerun-if-changed={}", file);
-    println!("cargo:rustc-link-arg=-T{}", file);
 }

--- a/cortex-r-examples/mps3-an536.ld
+++ b/cortex-r-examples/mps3-an536.ld
@@ -1,26 +1,13 @@
 /*
-RAM starts at 0x20000000.
+Memory configuration for the MPS3-AN536 machine.
 
-See https://github.com/qemu/qemu/blob/master/hw/arm/mpsr3.c
+See https://github.com/qemu/qemu/blob/master/hw/arm/mps3r.c
 */
 
 MEMORY {
-    RAM : ORIGIN = 0x20000000, LENGTH = 128M
+    QSPI : ORIGIN = 0x08000000, LENGTH = 8M
+    DDR  : ORIGIN = 0x20000000, LENGTH = 128M
 }
 
-ENTRY(_start)
-SECTIONS {
-    .startup ORIGIN(RAM) : {
-        *(.text.startup)
-    } > RAM
-    .text : { *(.text .text*) } > RAM
-    .rodata : { *(.rodata .rodata*) } > RAM
-    .data : { *(.data .data*) } > RAM
-    .bss : { *(.bss .bss* COMMON) } > RAM
-    /DISCARD/ : {
-        *(.note .note*)
-    }
-    . = ALIGN(16);
-    . += 0x100000; /* 1024kB of stack memory */
-    stack_top = .;
-}
+REGION_ALIAS("CODE", QSPI);
+REGION_ALIAS("DATA", DDR);

--- a/cortex-r-examples/src/bin/gic.rs
+++ b/cortex-r-examples/src/bin/gic.rs
@@ -7,6 +7,10 @@
 use cortex_r as _;
 use cortex_r_examples as _;
 
+use arm_gic::{
+    gicv3::{GicV3, Group, SgiTarget},
+    IntId,
+};
 use arm_semihosting::{debug, hprintln};
 
 /// The entry-point to the Rust application.
@@ -19,11 +23,6 @@ pub extern "C" fn kmain() {
     }
     debug::exit(debug::EXIT_SUCCESS);
 }
-
-use arm_gic::{
-    gicv3::{GicV3, Group, SecureIntGroup, SgiTarget},
-    IntId,
-};
 
 // Base addresses of the GICv3 distributor and redistributor.
 const GICD_BASE_ADDRESS: *mut u64 = 0xF000_0000usize as _;

--- a/cortex-r-examples/src/bin/gic.rs
+++ b/cortex-r-examples/src/bin/gic.rs
@@ -1,0 +1,86 @@
+//! GIC example for Arm Cortex-R52 on an MPS2-AN336
+
+#![no_std]
+#![no_main]
+
+// pull in our start-up code
+use cortex_r as _;
+use cortex_r_examples as _;
+
+use arm_semihosting::{debug, hprintln};
+
+/// The entry-point to the Rust application.
+///
+/// It is called by the start-up code in `cortex-m-rt`.
+#[no_mangle]
+pub extern "C" fn kmain() {
+    if let Err(e) = main() {
+        panic!("main returned {:?}", e);
+    }
+    debug::exit(debug::EXIT_SUCCESS);
+}
+
+use arm_gic::{
+    gicv3::{GicV3, Group, SecureIntGroup, SgiTarget},
+    IntId,
+};
+
+// Base addresses of the GICv3 distributor and redistributor.
+const GICD_BASE_ADDRESS: *mut u64 = 0xF000_0000usize as _;
+const GICR_BASE_ADDRESS: *mut u64 = 0xF010_0000usize as _;
+
+fn dump_cpsr() {
+    let cpsr = cortex_r::register::Cpsr::read();
+    hprintln!("CPSR: {:?}", cpsr);
+}
+
+/// The main function of our Rust application.
+///
+/// Called by [`kmain`].
+fn main() -> Result<(), core::fmt::Error> {
+    // Initialise the GIC.
+    hprintln!("Creating GIC driver...");
+    let mut gic = unsafe { GicV3::new(GICD_BASE_ADDRESS, GICR_BASE_ADDRESS) };
+    hprintln!("Calling git.setup()");
+    gic.setup();
+    hprintln!("Configure SGI");
+    // Configure an SGI and then send it to ourself.
+    let sgi_intid = IntId::sgi(3);
+    GicV3::set_priority_mask(0xFF);
+    gic.set_interrupt_priority(sgi_intid, 0x31);
+    gic.set_group(sgi_intid, Group::Group1NS);
+    hprintln!("gic.enable_interrupt()");
+    gic.enable_interrupt(sgi_intid, true);
+    hprintln!("Enabling interrupts...");
+    dump_cpsr();
+    unsafe {
+        cortex_r::interrupt::enable();
+    }
+    dump_cpsr();
+    hprintln!("Send SGI");
+    GicV3::send_sgi(
+        sgi_intid,
+        SgiTarget::List {
+            affinity3: 0,
+            affinity2: 0,
+            affinity1: 0,
+            target_list: 0b1,
+        },
+    );
+
+    for _ in 0..1_000_000 {
+        cortex_r::asm::nop();
+    }
+
+    Ok(())
+}
+
+#[no_mangle]
+unsafe extern "C" fn _irq_handler() {
+    hprintln!("> IRQ");
+    while let Some(int_id) = GicV3::get_and_acknowledge_interrupt() {
+        hprintln!("- IRQ handle {:?}", int_id);
+        GicV3::end_interrupt(int_id);
+    }
+    hprintln!("< IRQ");
+}

--- a/cortex-r-examples/src/bin/hello.rs
+++ b/cortex-r-examples/src/bin/hello.rs
@@ -26,5 +26,5 @@ fn main() -> Result<(), core::fmt::Error> {
     let x = 1.0f64;
     let y = x * 2.0;
     hprintln!("Hello, this is semihosting! x = {:0.3}, y = {:0.3}", x, y);
-    panic!("I am a panic");
+    panic!("I am an example panic");
 }

--- a/cortex-r-examples/src/bin/hello.rs
+++ b/cortex-r-examples/src/bin/hello.rs
@@ -7,11 +7,11 @@
 use cortex_r as _;
 use cortex_r_examples as _;
 
-use arm_semihosting::{debug, heprintln, hprintln};
+use arm_semihosting::hprintln;
 
 /// The entry-point to the Rust application.
 ///
-/// It is called by the start-up code in `lib.rs`.
+/// It is called by the start-up code in `cortex-m-rt`.
 #[no_mangle]
 pub extern "C" fn kmain() {
     if let Err(e) = main() {
@@ -27,16 +27,4 @@ fn main() -> Result<(), core::fmt::Error> {
     let y = x * 2.0;
     hprintln!("Hello, this is semihosting! x = {:0.3}, y = {:0.3}", x, y);
     panic!("I am a panic");
-}
-
-/// Called when the application raises an unrecoverable `panic!`.
-///
-/// Prints the panic to the console and then exits QEMU using a semihosting
-/// breakpoint.
-#[panic_handler]
-fn panic(info: &core::panic::PanicInfo) -> ! {
-    heprintln!("PANIC: {:?}", info);
-    loop {
-        debug::exit(debug::EXIT_FAILURE);
-    }
 }

--- a/cortex-r-examples/src/bin/registers.rs
+++ b/cortex-r-examples/src/bin/registers.rs
@@ -9,6 +9,10 @@ use cortex_r_examples as _;
 
 use arm_semihosting::hprintln;
 
+extern "C" {
+    static _stack_top: u32;
+}
+
 /// The entry-point to the Rust application.
 ///
 /// It is called by the start-up code in `cortex-m-rt`.
@@ -16,6 +20,8 @@ use arm_semihosting::hprintln;
 pub extern "C" fn kmain() {
     hprintln!("{:?}", cortex_r::register::Midr::read());
     hprintln!("{:?}", cortex_r::register::Cpsr::read());
+
+    hprintln!("_stack_top: {:p}", core::ptr::addr_of!(_stack_top));
 
     hprintln!(
         "{:?} before setting C, I and Z",

--- a/cortex-r-examples/src/bin/registers.rs
+++ b/cortex-r-examples/src/bin/registers.rs
@@ -1,0 +1,32 @@
+//! Registers example for Arm Cortex-R
+
+#![no_std]
+#![no_main]
+
+// pull in our start-up code
+use cortex_r as _;
+use cortex_r_examples as _;
+
+use arm_semihosting::hprintln;
+
+/// The entry-point to the Rust application.
+///
+/// It is called by the start-up code in `cortex-m-rt`.
+#[no_mangle]
+pub extern "C" fn kmain() {
+    hprintln!("{:?}", cortex_r::register::Midr::read());
+    hprintln!("{:?}", cortex_r::register::Cpsr::read());
+
+    hprintln!(
+        "{:?} before setting C, I and Z",
+        cortex_r::register::Sctlr::read()
+    );
+    cortex_r::register::Sctlr::modify(|w| {
+        w.set_c();
+        w.set_i();
+        w.set_z();
+    });
+    hprintln!("{:?} after", cortex_r::register::Sctlr::read());
+
+    arm_semihosting::debug::exit(arm_semihosting::debug::EXIT_SUCCESS);
+}

--- a/cortex-r-examples/src/bin/svc.rs
+++ b/cortex-r-examples/src/bin/svc.rs
@@ -36,4 +36,8 @@ fn main() -> Result<(), core::fmt::Error> {
 #[no_mangle]
 unsafe extern "C" fn _svc_handler(arg: u32) {
     hprintln!("In _svc_handler, with arg={:#06x}", arg,);
+    if arg == 0xABCDEF {
+        // test nested SVC calls
+        cortex_r::svc!(0x456789);
+    }
 }

--- a/cortex-r-examples/src/bin/svc.rs
+++ b/cortex-r-examples/src/bin/svc.rs
@@ -35,5 +35,9 @@ fn main() -> Result<(), core::fmt::Error> {
 /// This is our SVC exception handler
 #[no_mangle]
 unsafe extern "C" fn _svc_handler(arg: u32, state: *const [u32; 6]) {
-    hprintln!("SVC interrupt, with arg={:#06x}, state={:08x?}", arg, state.read());
+    hprintln!(
+        "SVC interrupt, with arg={:#06x}, state={:08x?}",
+        arg,
+        state.read()
+    );
 }

--- a/cortex-r-examples/src/bin/svc.rs
+++ b/cortex-r-examples/src/bin/svc.rs
@@ -34,10 +34,6 @@ fn main() -> Result<(), core::fmt::Error> {
 
 /// This is our SVC exception handler
 #[no_mangle]
-unsafe extern "C" fn _svc_handler(arg: u32, state: *const [u32; 6]) {
-    hprintln!(
-        "SVC interrupt, with arg={:#06x}, state={:08x?}",
-        arg,
-        state.read()
-    );
+unsafe extern "C" fn _svc_handler(arg: u32) {
+    hprintln!("In _svc_handler, with arg={:#06x}", arg,);
 }

--- a/cortex-r-examples/src/bin/svc.rs
+++ b/cortex-r-examples/src/bin/svc.rs
@@ -1,0 +1,39 @@
+//! SVC (software interrupt) example for Arm Cortex-R
+
+#![no_std]
+#![no_main]
+
+// pull in our start-up code
+use cortex_r as _;
+use cortex_r_examples as _;
+
+use arm_semihosting::hprintln;
+
+/// The entry-point to the Rust application.
+///
+/// It is called by the start-up code in `cortex-m-rt`.
+#[no_mangle]
+pub extern "C" fn kmain() {
+    if let Err(e) = main() {
+        panic!("main returned {:?}", e);
+    }
+}
+
+/// The main function of our Rust application.
+///
+/// Called by [`kmain`].
+fn main() -> Result<(), core::fmt::Error> {
+    let x = 1;
+    let y = x + 1;
+    let z = (y as f64) * 1.5;
+    hprintln!("x = {}, y = {}, z = {:0.3}", x, y, z);
+    cortex_r::svc!(0xABCDEF);
+    hprintln!("x = {}, y = {}, z = {:0.3}", x, y, z);
+    panic!("I am an example panic");
+}
+
+/// This is our SVC exception handler
+#[no_mangle]
+unsafe extern "C" fn _svc_handler(arg: u32, state: *const [u32; 6]) {
+    hprintln!("SVC interrupt, with arg={:#06x}, state={:08x?}", arg, state.read());
+}

--- a/cortex-r-examples/src/lib.rs
+++ b/cortex-r-examples/src/lib.rs
@@ -5,3 +5,17 @@
 // Need this to bring in the start-up function
 
 use cortex_r_rt as _;
+
+/// Called when the application raises an unrecoverable `panic!`.
+///
+/// Prints the panic to the console and then exits QEMU using a semihosting
+/// breakpoint.
+#[panic_handler]
+#[cfg(target_os = "none")]
+fn panic(info: &core::panic::PanicInfo) -> ! {
+    use arm_semihosting::{debug, heprintln};
+    heprintln!("PANIC: {:#?}", info);
+    loop {
+        debug::exit(debug::EXIT_FAILURE);
+    }
+}

--- a/cortex-r-examples/versatileab.ld
+++ b/cortex-r-examples/versatileab.ld
@@ -1,26 +1,12 @@
 /*
-RAM starts at 0x20000000.
+Memory configuration for the Arm Versatile Peripheral Board.
 
-See https://github.com/qemu/qemu/blob/master/hw/arm/mpsr3.c
+See https://github.com/qemu/qemu/blob/master/hw/arm/versatilepb.c
 */
 
 MEMORY {
-    RAM : ORIGIN = 0, LENGTH = 128M
+    SDRAM : ORIGIN = 0, LENGTH = 128M
 }
 
-ENTRY(_start)
-SECTIONS {
-    .startup ORIGIN(RAM) : {
-        *(.text.startup)
-    } > RAM
-    .text : { *(.text .text*) } > RAM
-    .rodata : { *(.rodata .rodata*) } > RAM
-    .data : { *(.data .data*) } > RAM
-    .bss : { *(.bss .bss* COMMON) } > RAM
-    /DISCARD/ : {
-        *(.note .note*)
-    }
-    . = ALIGN(16);
-    . += 0x100000; /* 1024kB of stack memory */
-    stack_top = .;
-}
+REGION_ALIAS("CODE", SDRAM);
+REGION_ALIAS("DATA", SDRAM);

--- a/cortex-r-rt/Cargo.toml
+++ b/cortex-r-rt/Cargo.toml
@@ -11,6 +11,7 @@ version = "0.1.0"
 
 [dependencies]
 arm-semihosting = { version = "0.1.0", path = "../arm-semihosting" }
+cortex-r = { version = "0.1.0", path = "../cortex-r" }
 
 [features]
 # Enable the FPU on start-up, even on a soft-float EABI target

--- a/cortex-r-rt/Cargo.toml
+++ b/cortex-r-rt/Cargo.toml
@@ -6,7 +6,7 @@ name = "cortex-r-rt"
 description = "Run-time support for Arm Cortex-R"
 readme = "README.md"
 repository = "https://github.com/ferrous-systems/cortex-r.git"
-rust-version = "1.76"
+rust-version = "1.82"
 version = "0.1.0"
 
 [dependencies]

--- a/cortex-r-rt/Cargo.toml
+++ b/cortex-r-rt/Cargo.toml
@@ -10,6 +10,7 @@ rust-version = "1.76"
 version = "0.1.0"
 
 [dependencies]
+arm-semihosting = { version = "0.1.0", path = "../arm-semihosting" }
 
 [features]
 # Enable the FPU on start-up, even on a soft-float EABI target

--- a/cortex-r-rt/README.md
+++ b/cortex-r-rt/README.md
@@ -2,7 +2,7 @@
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.76.0 and up. It *might*
+This crate is guaranteed to compile on stable Rust 1.82.0 and up. It *might*
 compile with older versions but that may change in any new patch release.
 
 ## Licence

--- a/cortex-r-rt/build.rs
+++ b/cortex-r-rt/build.rs
@@ -1,9 +1,24 @@
-//! # Build script for the Cortex-R Examples
+//! # Build script for the Cortex-R Runtime
 //!
 //! This script only executes when using `cargo` to build the project.
 //!
 //! Copyright (c) Ferrous Systems, 2025
 
+use std::io::Write;
+
 fn main() {
     arm_targets::process();
+    write("link.x", include_bytes!("link.x"));
+}
+
+fn write(file: &str, contents: &[u8]) {
+    // Put linker file in our output directory and ensure it's on the
+    // linker search path.
+    let out = &std::path::PathBuf::from(std::env::var_os("OUT_DIR").unwrap());
+    std::fs::File::create(out.join(file))
+        .unwrap()
+        .write_all(contents)
+        .unwrap();
+    println!("cargo:rustc-link-search={}", out.display());
+    println!("cargo:rerun-if-changed={}", file);
 }

--- a/cortex-r-rt/link.x
+++ b/cortex-r-rt/link.x
@@ -3,7 +3,7 @@ Basic Cortex-R linker script.
 
 You must supply a file called `memory.x` which defines the memory regions 'CODE' and 'DATA'.
 
-The stack pointer will be the top of the DATA region.
+The stack pointer(s) will be (near) the top of the DATA region by default.
 */
 
 INCLUDE memory.x
@@ -15,8 +15,8 @@ SECTIONS {
     .text : {
         /* The vector table must come first */
         *(.vector_table)
-        /* This is our Fast Interrupt Request function - it sits right after the vector table */
-        *(.text.fiq_handler)
+        /* Our exception handling routines */
+        *(.text.handlers)
         /* Now the rest of the code */
         *(.text .text*)
     } > CODE
@@ -39,9 +39,25 @@ SECTIONS {
 
 }
 
+/*
+We reserve some space at the top of the RAM for our stacks. We have an IRQ stack
+and a FIQ stack, plus the remainder is our system stack.
+
+You must keep _stack_top and the stack sizes aligned to eight byte boundaries.
+*/
 PROVIDE(_stack_top = ORIGIN(DATA) + LENGTH(DATA));
-PROVIDE(_undefined_handler=_default_handler);
-PROVIDE(_svc_handler=_default_handler);
-PROVIDE(_prefetch_handler=_default_handler);
-PROVIDE(_abort_handler=_default_handler);
-PROVIDE(_irq_handler=_default_handler);
+PROVIDE(_fiq_stack_size = 0x100);
+PROVIDE(_irq_stack_size = 0x1000);
+PROVIDE(_svc_stack_size = 0x1000);
+
+ASSERT(_stack_top % 8 == 0, "ERROR(cortex-r-rt): top of stack is not 8-byte aligned");
+ASSERT(_fiq_stack_size % 8 == 0, "ERROR(cortex-r-rt): size of FIQ stack is not 8-byte aligned");
+ASSERT(_irq_stack_size % 8 == 0, "ERROR(cortex-r-rt): size of IRQ stack is not 8-byte aligned");
+
+PROVIDE(_asm_undefined_handler =_asm_default_handler);
+PROVIDE(_asm_prefetch_handler  =_asm_default_handler);
+PROVIDE(_asm_abort_handler     =_asm_default_handler);
+PROVIDE(_asm_fiq_handler       =_asm_default_fiq_handler);
+PROVIDE(_irq_handler           =_default_handler);
+PROVIDE(_svc_handler           =_default_handler);
+PROVIDE(_start                 =_default_start);

--- a/cortex-r-rt/link.x
+++ b/cortex-r-rt/link.x
@@ -1,0 +1,47 @@
+/*
+Basic Cortex-R linker script.
+
+You must supply a file called `memory.x` which defines the memory regions 'CODE' and 'DATA'.
+
+The stack pointer will be the top of the DATA region.
+*/
+
+INCLUDE memory.x
+
+ENTRY(_vector_table);
+EXTERN(_vector_table);
+
+SECTIONS {
+    .text : {
+        /* The vector table must come first */
+        *(.vector_table)
+        /* This is our Fast Interrupt Request function - it sits right after the vector table */
+        *(.text.fiq_handler)
+        /* Now the rest of the code */
+        *(.text .text*)
+    } > CODE
+
+    .rodata : {
+        *(.rodata .rodata*)
+    } > CODE
+
+    .data : {
+        *(.data .data*)
+    } > DATA
+
+    .bss : {
+        *(.bss .bss* COMMON)
+    } > DATA
+
+    /DISCARD/ : {
+        *(.note .note*)
+    }
+
+}
+
+PROVIDE(_stack_top = ORIGIN(DATA) + LENGTH(DATA));
+PROVIDE(_undefined_handler=_default_handler);
+PROVIDE(_svc_handler=_default_handler);
+PROVIDE(_prefetch_handler=_default_handler);
+PROVIDE(_abort_handler=_default_handler);
+PROVIDE(_irq_handler=_default_handler);

--- a/cortex-r-rt/src/lib.rs
+++ b/cortex-r-rt/src/lib.rs
@@ -4,7 +4,7 @@
 
 #[cfg(all(
     any(arm_architecture = "v7-r", arm_architecture = "v8-r"),
-    any(arm_float_abi = "hard", feature = "eabi-fpu")
+    any(target_abi = "eabihf", feature = "eabi-fpu")
 ))]
 core::arch::global_asm!(
     r#"
@@ -36,7 +36,7 @@ _start:
 
 #[cfg(all(
     any(arm_architecture = "v7-r", arm_architecture = "v8-r"),
-    not(any(arm_float_abi = "hard", feature = "eabi-fpu"))
+    not(any(target_abi = "eabihf", feature = "eabi-fpu"))
 ))]
 core::arch::global_asm!(
     r#"

--- a/cortex-r-rt/src/lib.rs
+++ b/cortex-r-rt/src/lib.rs
@@ -100,7 +100,6 @@ pub extern "C" fn _default_handler() {
 core::arch::global_asm!(
     r#"
     .section .vector_table
-    .code 32
     .align 0
 
     .global _vector_table
@@ -231,7 +230,6 @@ macro_rules! restore_context {
 core::arch::global_asm!(
     r#"
     .section .text.handlers
-    .code 32
     // Work around https://github.com/rust-lang/rust/issues/127269
     .fpu vfp3-d16
     .align 0
@@ -312,7 +310,6 @@ macro_rules! fpu_enable {
 core::arch::global_asm!(
     r#"
     .section .text.startup
-    .code 32
     .align 0
     // Work around https://github.com/rust-lang/rust/issues/127269
     .fpu vfp3-d16
@@ -375,7 +372,6 @@ core::arch::global_asm!(
 core::arch::global_asm!(
     r#"
     .section .text.startup
-    .code 32
     .align 0
 
     .global _default_start
@@ -394,7 +390,6 @@ core::arch::global_asm!(
 core::arch::global_asm!(
     r#"
     .section .text.startup
-    .code 32
     .align 0
     
     .global _default_start

--- a/cortex-r-rt/src/lib.rs
+++ b/cortex-r-rt/src/lib.rs
@@ -416,11 +416,11 @@ core::arch::global_asm!(
         mcr     p15, 4, r0, c12, c0, 0
         // Configure HACTLR to let us enter EL1
         mrc     p15, 4, r0, c1, c0, 1
-        orr     r0, r0, #0x7700
-        orr     r0, r0, #0x0083
+        mov     r1, {hactlr_bits}
+        orr     r0, r0, r1
         mcr     p15, 4, r0, c1, c0, 1
         // Program the SPSR - enter sytem mode (0x1F) in Arm mode with IRQ, FIQ masked
-        mov		r0, #0xDF
+        mov		r0, {sys_mode}
         msr		spsr_hyp, r0
         adr		r0, 1f
         msr		elr_hyp, r0
@@ -437,4 +437,6 @@ core::arch::global_asm!(
     "#,
     cpsr_mode_mask = const cortex_r::register::Cpsr::MODE_BITS,
     cpsr_mode_hyp = const cortex_r::register::Cpsr::HYP_MODE,
+    hactlr_bits = const cortex_r::register::Hactlr::CPUACTLR_BIT | cortex_r::register::Hactlr::CDBGDCI_BIT | cortex_r::register::Hactlr::FLASHIFREGIONR_BIT | cortex_r::register::Hactlr::PERIPHPREGIONR_BIT | cortex_r::register::Hactlr::QOSR_BIT | cortex_r::register::Hactlr::BUSTIMEOUTR_BIT | cortex_r::register::Hactlr::INTMONR_BIT | cortex_r::register::Hactlr::ERR_BIT | cortex_r::register::Hactlr::TESTR1_BIT,
+    sys_mode = const cortex_r::register::Cpsr::SYS_MODE | cortex_r::register::Cpsr::I_BIT | cortex_r::register::Cpsr::F_BIT,
 );

--- a/cortex-r-rt/src/lib.rs
+++ b/cortex-r-rt/src/lib.rs
@@ -2,6 +2,16 @@
 
 #![no_std]
 
+/// Our default exception handler.
+///
+/// We end up here if an exception fires and the weak 'PROVIDE' in the link.x
+/// file hasn't been over-ridden.
+#[no_mangle]
+pub extern "C" fn _default_handler() {
+    arm_semihosting::hprintln!("Unhandled exception!");
+    arm_semihosting::debug::exit(arm_semihosting::debug::EXIT_FAILURE);
+}
+
 // The Interrupt Vector Table
 #[cfg(any(arm_architecture = "v7-r", arm_architecture = "v8-r"))]
 core::arch::global_asm!(
@@ -11,13 +21,13 @@ core::arch::global_asm!(
 .code 32
 .align 0
 _vector_table:
-    ldr pc,=_start
-    ldr pc,=_asm_undefined_handler
-    ldr pc,=_asm_svc_handler
-    ldr pc,=_asm_prefetch_handler
-    ldr pc,=_asm_abort_handler
+    ldr pc, =_start
+    ldr pc, =_asm_undefined_handler
+    ldr pc, =_asm_svc_handler
+    ldr pc, =_asm_prefetch_handler
+    ldr pc, =_asm_abort_handler
     nop
-    ldr pc,=_asm_irq_handler
+    ldr pc, =_asm_irq_handler
 "#
 );
 
@@ -92,12 +102,6 @@ _asm_irq_handler:
     b       _irq_handler
     // restore state (the ^ means copy SPSR back to CPSR)
     ldmia    sp!, {{r0-r3, r12, pc}}^
-
-// Our default (c-compatible) handler crashes the CPU
-.global _default_handler
-_default_handler:
-    udf 0
-    b       _default_handler
 "#
 );
 
@@ -217,17 +221,14 @@ _asm_irq_handler:
     vmsr    FPSCR, r0
     vpop    {{d0-d7}}
     ldmia    sp!, {{r0-r3, r12, pc}}^
-
-// Our default (c-compatible) handler crashes the CPU
-.global _default_handler
-_default_handler:
-    udf 0
-    b       _default_handler
 "#
 );
 
+// Start-up code for Armv7-R with an FPU
+//
+// We boot into Supervisor mode, set up a stack pointer, and run `kmain` in supervisor mode.
 #[cfg(all(
-    any(arm_architecture = "v7-r", arm_architecture = "v8-r"),
+    arm_architecture = "v7-r",
     any(target_abi = "eabihf", feature = "eabi-fpu")
 ))]
 core::arch::global_asm!(
@@ -236,6 +237,7 @@ core::arch::global_asm!(
 .global _start
 .code 32
 .align 0
+.arch armv7-r
 // Work around https://github.com/rust-lang/rust/issues/127269
 .fpu vfp3-d16
 
@@ -257,8 +259,11 @@ _start:
 "#
 );
 
+// Start-up code for Armv7-R without an FPU
+//
+// We boot into Supervisor mode, set up a stack pointer, and run `kmain` in supervisor mode.
 #[cfg(all(
-    any(arm_architecture = "v7-r", arm_architecture = "v8-r"),
+    arm_architecture = "v7-r",
     not(any(target_abi = "eabihf", feature = "eabi-fpu"))
 ))]
 core::arch::global_asm!(
@@ -266,11 +271,69 @@ core::arch::global_asm!(
 .section .text.startup
 .global _start
 .code 32
+.arch armv7-r
 .align 0
 
 _start:
     // Set stack pointer
     ldr     sp, =_stack_top
+    // Jump to application
+    bl      kmain
+    // In case the application returns, loop forever
+    b       .
+"#
+);
+
+// Start-up code for Armv8-R
+//
+// We boot into EL2, set up a stack pointer, and run `kmain` in EL1.
+#[cfg(arm_architecture = "v8-r")]
+core::arch::global_asm!(
+    r#"
+.section .text.startup
+.global _start
+.code 32
+.align 0
+// Work around https://github.com/rust-lang/rust/issues/127269
+.fpu vfp3-d16
+
+_start:
+    // Are we in EL2? If not, skip the EL2 setup portion
+    mrs     r0, cpsr
+    and     r0, r0, #0x1f
+    cmp     r0, #0x1a
+    bne     1f
+    // Set stack pointer
+    ldr     sp, =_stack_top
+    // Set the HVBAR (for EL2) to _vector_table
+    ldr     r0, =_vector_table
+    mcr     p15, 4, r0, c12, c0, 0
+    // Configure HACTLR to let us enter EL1
+    mrc     p15, 4, r0, c1, c0, 1
+    orr     r0, r0, #0x7700
+    orr     r0, r0, #0x0083
+    mcr     p15, 4, r0, c1, c0, 1
+    // Program the SPSR - enter supervisor mode in Arm mode with IRQ, FIQ and Async Abort masked
+    mov		r0, #0x1DF
+	msr		spsr_hyp, r0
+	adr		r0, 1f
+	msr		elr_hyp, r0
+	dsb
+	isb
+	eret
+1:
+    // Set stack pointer (we can trash the EL2 stack - we're not coming back)
+    ldr     sp, =_stack_top
+    // Set the VBAR (for EL1) to _vector_table
+    ldr     r0, =_vector_table
+    mcr     p15, 0, r0, c12, c0, 0
+    // Allow VFP coprocessor access
+    mrc     p15, 0, r0, c1, c0, 2
+    orr     r0, r0, #0xF00000
+    mcr     p15, 0, r0, c1, c0, 2
+    // Enable VFP
+    mov     r0, #0x40000000
+    vmsr    fpexc, r0
     // Jump to application
     bl      kmain
     // In case the application returns, loop forever

--- a/cortex-r-rt/src/lib.rs
+++ b/cortex-r-rt/src/lib.rs
@@ -261,6 +261,7 @@ core::arch::global_asm!(
     // `extern "C" fn irq_handler();`
     .global _asm_irq_handler
     _asm_irq_handler:
+        sub     lr, lr, 4
         srsfd   sp!, {irq_mode}
     "#,
     save_context!(),

--- a/cortex-r-rt/src/lib.rs
+++ b/cortex-r-rt/src/lib.rs
@@ -2,13 +2,236 @@
 
 #![no_std]
 
+// The Interrupt Vector Table
+#[cfg(any(arm_architecture = "v7-r", arm_architecture = "v8-r"))]
+core::arch::global_asm!(
+    r#"
+.section .vector_table
+.global _vector_table
+.code 32
+.align 0
+_vector_table:
+    ldr pc,=_start
+    ldr pc,=_asm_undefined_handler
+    ldr pc,=_asm_svc_handler
+    ldr pc,=_asm_prefetch_handler
+    ldr pc,=_asm_abort_handler
+    nop
+    ldr pc,=_asm_irq_handler
+"#
+);
+
+// Our assembly language exception handlers when we don't have an FPU
+#[cfg(all(
+    any(arm_architecture = "v7-r", arm_architecture = "v8-r"),
+    not(any(target_abi = "eabihf", feature = "eabi-fpu"))
+))]
+core::arch::global_asm!(
+    r#"
+.section .text.handlers
+.code 32
+.arch armv7-r
+.align 0
+
+// Called from the vector table when we have an undefined exception.
+// Saves state and calls a C-compatible handler
+.global _asm_undefined_handler
+_asm_undefined_handler:
+    // save state
+    push    {{r0-r3, r12, lr}}
+    // call C handler
+    b       _undefined_handler
+    // restore state (the ^ means copy SPSR back to CPSR)
+    ldmia    sp!, {{r0-r3, r12, pc}}^
+
+// Called from the vector table when we have an software interrupt.
+// Saves state and calls a C-compatible handler
+.global _asm_svc_handler
+_asm_svc_handler:
+    push     {{r0-r3, r12, lr}}
+    mov      r1, sp                   // Set pointer to parameters
+    tst      r0, #0x20                // Occurred in Thumb state?
+    ldrhne   r0, [lr,#-2]             // Yes: Load halfword and...
+    bicne    r0, r0, #0xFF00          // ...extract comment field
+    ldreq    r0, [lr,#-4]             // No: Load word and...
+    biceq    r0, r0, #0xFF000000      // ...extract comment field
+    // r0 now contains SVC number
+    // r1 now contains pointer to stacked register
+    bl       _svc_handler
+    ldmia    sp!, {{r0-r3, r12, pc}}^
+
+// Called from the vector table when we have an prefetch exception.
+// Saves state and calls a C-compatible handler
+.global _asm_prefetch_handler
+_asm_prefetch_handler:
+    // save state
+    push    {{r0-r3, r12, lr}}
+    // call C handler
+    b       _prefetch_handler
+    // restore state (the ^ means copy SPSR back to CPSR)
+    ldmia    sp!, {{r0-r3, r12, pc}}^
+
+// Called from the vector table when we have an abort exception.
+// Saves state and calls a C-compatible handler
+.global _asm_abort_handler
+_asm_abort_handler:
+    // save state
+    push    {{r0-r3, r12, lr}}
+    // call C handler
+    b       _abort_handler
+    // restore state (the ^ means copy SPSR back to CPSR)
+    ldmia    sp!, {{r0-r3, r12, pc}}^
+
+// Called from the vector table when we have an interrupt.
+// Saves state and calls a C-compatible handler
+.global _asm_irq_handler
+_asm_irq_handler:
+    // save state
+    push    {{r0-r3, r12, lr}}
+    // call C handler
+    b       _irq_handler
+    // restore state (the ^ means copy SPSR back to CPSR)
+    ldmia    sp!, {{r0-r3, r12, pc}}^
+
+// Our default (c-compatible) handler crashes the CPU
+.global _default_handler
+_default_handler:
+    udf 0
+    b       _default_handler
+"#
+);
+
+// Our assembly language exception handlers when we do have an FPU
 #[cfg(all(
     any(arm_architecture = "v7-r", arm_architecture = "v8-r"),
     any(target_abi = "eabihf", feature = "eabi-fpu")
 ))]
 core::arch::global_asm!(
     r#"
+.section .text.handlers
+.code 32
+.align 0
+// Work around https://github.com/rust-lang/rust/issues/127269
+.fpu vfp3-d16
 
+// Called from the vector table when we have an undefined exception.
+// Saves state and calls a C-compatible handler
+.global _asm_undefined_handler
+_asm_undefined_handler:
+    // save state
+    push    {{r0-r3, r12, lr}}
+    vpush   {{d0-d7}}
+	vmrs    r0, FPSCR
+	vmrs    r1, FPEXC
+    push    {{r0-r1}}
+    // call C handler
+    b       _undefined_handler
+    // restore state (the ^ means copy SPSR back to CPSR)
+    pop     {{r0-r1}}
+    vmsr    FPEXC, r1
+    vmsr    FPSCR, r0
+    vpop    {{d0-d7}}
+    ldmia    sp!, {{r0-r3, r12, pc}}^
+
+// Called from the vector table when we have an software interrupt.
+// Saves state and calls a C-compatible handler
+.global _asm_svc_handler
+_asm_svc_handler:
+    // save state
+    push    {{r0-r3, r12, lr}}
+    vpush   {{d0-d7}}
+	vmrs    r0, FPSCR
+	vmrs    r1, FPEXC
+    push    {{r0-r1}}
+
+    mov     r1, sp                   // Set pointer to parameters
+    tst     r0, #0x20                // Occurred in Thumb state?
+    ldrhne  r0, [lr,#-2]             // Yes: Load halfword and...
+    bicne   r0, r0, #0xFF00          // ...extract comment field
+    ldreq   r0, [lr,#-4]             // No: Load word and...
+    biceq   r0, r0, #0xFF000000      // ...extract comment field
+    // r0 now contains SVC number
+    // r1 now contains pointer to stacked register
+    bl      _svc_handler
+
+    // restore state (the ^ means copy SPSR back to CPSR)
+    pop     {{r0-r1}}
+    vmsr    FPEXC, r1
+    vmsr    FPSCR, r0
+    vpop    {{d0-d7}}
+    ldmia    sp!, {{r0-r3, r12, pc}}^
+
+// Called from the vector table when we have an prefetch exception.
+// Saves state and calls a C-compatible handler
+.global _asm_prefetch_handler
+_asm_prefetch_handler:
+    // save state
+    push    {{r0-r3, r12, lr}}
+    vpush   {{d0-d7}}
+	vmrs    r0, FPSCR
+	vmrs    r1, FPEXC
+    push    {{r0-r1}}
+    // call C handler
+    b       _prefetch_handler
+    // restore state (the ^ means copy SPSR back to CPSR)
+    pop     {{r0-r1}}
+    vmsr    FPEXC, r1
+    vmsr    FPSCR, r0
+    vpop    {{d0-d7}}
+    ldmia    sp!, {{r0-r3, r12, pc}}^
+
+// Called from the vector table when we have an abort exception.
+// Saves state and calls a C-compatible handler
+.global _asm_abort_handler
+_asm_abort_handler:
+    // save state
+    push    {{r0-r3, r12, lr}}
+    vpush   {{d0-d7}}
+	vmrs    r0, FPSCR
+	vmrs    r1, FPEXC
+    push    {{r0-r1}}
+    // call C handler
+    b       _abort_handler
+    // restore state (the ^ means copy SPSR back to CPSR)
+    pop     {{r0-r1}}
+    vmsr    FPEXC, r1
+    vmsr    FPSCR, r0
+    vpop    {{d0-d7}}
+    ldmia    sp!, {{r0-r3, r12, pc}}^
+
+// Called from the vector table when we have an interrupt.
+// Saves state and calls a C-compatible handler
+.global _asm_irq_handler
+_asm_irq_handler:
+    // save state
+    push    {{r0-r3, r12, lr}}
+    vpush   {{d0-d7}}
+	vmrs    r0, FPSCR
+	vmrs    r1, FPEXC
+    push    {{r0-r1}}
+    // call C handler
+    b       _irq_handler
+    // restore state (the ^ means copy SPSR back to CPSR)
+    pop     {{r0-r1}}
+    vmsr    FPEXC, r1
+    vmsr    FPSCR, r0
+    vpop    {{d0-d7}}
+    ldmia    sp!, {{r0-r3, r12, pc}}^
+
+// Our default (c-compatible) handler crashes the CPU
+.global _default_handler
+_default_handler:
+    udf 0
+    b       _default_handler
+"#
+);
+
+#[cfg(all(
+    any(arm_architecture = "v7-r", arm_architecture = "v8-r"),
+    any(target_abi = "eabihf", feature = "eabi-fpu")
+))]
+core::arch::global_asm!(
+    r#"
 .section .text.startup
 .global _start
 .code 32
@@ -18,18 +241,18 @@ core::arch::global_asm!(
 
 _start:
     // Set stack pointer
-    ldr sp, =stack_top
+    ldr     sp, =_stack_top
     // Allow VFP coprocessor access
-    mrc p15, 0, r0, c1, c0, 2
-    orr r0, r0, #0xF00000
-    mcr p15, 0, r0, c1, c0, 2
+    mrc     p15, 0, r0, c1, c0, 2
+    orr     r0, r0, #0xF00000
+    mcr     p15, 0, r0, c1, c0, 2
     // Enable VFP
-    mov r0, #0x40000000
-    vmsr fpexc, r0
+    mov     r0, #0x40000000
+    vmsr    fpexc, r0
     // Jump to application
-    bl kmain
+    bl      kmain
     // In case the application returns, loop forever
-    b .
+    b       .
 
 "#
 );
@@ -40,7 +263,6 @@ _start:
 ))]
 core::arch::global_asm!(
     r#"
-
 .section .text.startup
 .global _start
 .code 32
@@ -48,11 +270,10 @@ core::arch::global_asm!(
 
 _start:
     // Set stack pointer
-    ldr sp, =stack_top
+    ldr     sp, =_stack_top
     // Jump to application
-    bl kmain
+    bl      kmain
     // In case the application returns, loop forever
-    b .
-
+    b       .
 "#
 );

--- a/cortex-r/Cargo.toml
+++ b/cortex-r/Cargo.toml
@@ -13,6 +13,9 @@ version = "0.1.0"
 critical-section = { version = "1.2.0", features = ["restore-state-bool"], optional = true }
 defmt = { version = "0.3", optional = true }
 
+[build-dependencies]
+arm-targets = { version = "0.1.0", path = "../arm-targets" }
+
 [features]
 # Adds a critical-section implementation that only disables interrupts.
 # This is not sound on multi-core systems because interrupts are per-core.

--- a/cortex-r/Cargo.toml
+++ b/cortex-r/Cargo.toml
@@ -10,4 +10,12 @@ rust-version = "1.76"
 version = "0.1.0"
 
 [dependencies]
-critical-section = { version = "1.2.0", features = ["restore-state-bool"] }
+critical-section = { version = "1.2.0", features = ["restore-state-bool"], optional = true }
+defmt = { version = "0.3", optional = true }
+
+[features]
+# Adds a critical-section implementation that only disables interrupts.
+# This is not sound on multi-core systems because interrupts are per-core.
+critical-section-single-core = ["critical-section"]
+# Adds defmt::Format implementation for the register types
+defmt = ["dep:defmt"]

--- a/cortex-r/Cargo.toml
+++ b/cortex-r/Cargo.toml
@@ -6,7 +6,7 @@ name = "cortex-r"
 description = "CPU support for Arm Cortex-R"
 readme = "README.md"
 repository = "https://github.com/ferrous-systems/cortex-r.git"
-rust-version = "1.76"
+rust-version = "1.82"
 version = "0.1.0"
 
 [dependencies]

--- a/cortex-r/README.md
+++ b/cortex-r/README.md
@@ -2,7 +2,7 @@
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.76.0 and up. It *might*
+This crate is guaranteed to compile on stable Rust 1.82.0 and up. It *might*
 compile with older versions but that may change in any new patch release.
 
 ## Licence

--- a/cortex-r/build.rs
+++ b/cortex-r/build.rs
@@ -1,0 +1,9 @@
+//! # Build script for the Cortex-R library
+//!
+//! This script only executes when using `cargo` to build the project.
+//!
+//! Copyright (c) Ferrous Systems, 2025
+
+fn main() {
+    arm_targets::process();
+}

--- a/cortex-r/src/asm.rs
+++ b/cortex-r/src/asm.rs
@@ -1,0 +1,41 @@
+//! Simple assembly routines
+
+/// Emit an DSB instruction
+#[inline]
+pub fn dsb() {
+    unsafe {
+        core::arch::asm!("dsb");
+    }
+}
+
+/// Emit an ISB instruction
+#[inline]
+pub fn isb() {
+    unsafe {
+        core::arch::asm!("isb");
+    }
+}
+
+/// Emit an NOP instruction
+#[inline]
+pub fn nop() {
+    unsafe {
+        core::arch::asm!("nop");
+    }
+}
+
+/// Emit an WFI instruction
+#[inline]
+pub fn wfi() {
+    unsafe {
+        core::arch::asm!("wfi");
+    }
+}
+
+/// Emit an WFE instruction
+#[inline]
+pub fn wfe() {
+    unsafe {
+        core::arch::asm!("wfe");
+    }
+}

--- a/cortex-r/src/critical_section.rs
+++ b/cortex-r/src/critical_section.rs
@@ -9,7 +9,8 @@ critical_section::set_impl!(SingleCoreCriticalSection);
 
 unsafe impl critical_section::Impl for SingleCoreCriticalSection {
     unsafe fn acquire() -> critical_section::RawRestoreState {
-        let was_active = crate::register::Cpsr::read().i();
+        // the i bit means "masked"
+        let was_active = !crate::register::Cpsr::read().i();
         crate::interrupt::disable();
         atomic::compiler_fence(atomic::Ordering::SeqCst);
         was_active

--- a/cortex-r/src/interrupt.rs
+++ b/cortex-r/src/interrupt.rs
@@ -2,7 +2,8 @@
 
 /// Enable interrupts
 ///
-/// Doesn't work in User mode
+/// * Doesn't work in User mode.
+/// * Doesn't enable FIQ.
 ///
 /// # Safety
 ///
@@ -17,9 +18,10 @@ pub unsafe fn enable() {
     };
 }
 
-/// Disable interrupts
+/// Disable IRQ
 ///
-/// Doesn't work in User mode
+/// * Doesn't work in User mode.
+/// * Doesn't disable FIQ.
 #[inline]
 pub fn disable() {
     // Safety: We're atomically clearing a bit in a special register
@@ -31,7 +33,8 @@ pub fn disable() {
 
 /// Run with interrupts disabled
 ///
-/// Doesn't work in User mode
+/// * Doesn't work in User mode.
+/// * Doesn't disable FIQ.
 #[inline]
 pub fn free<F, T>(f: F) -> T
 where

--- a/cortex-r/src/interrupt.rs
+++ b/cortex-r/src/interrupt.rs
@@ -1,0 +1,50 @@
+//! Interrupts on Arm Cortex-R
+
+/// Enable interrupts
+///
+/// Doesn't work in User mode
+///
+/// # Safety
+///
+/// Do not call this function inside an interrupt-based critical section
+#[inline]
+pub unsafe fn enable() {
+    // Safety: We're atomically setting a bit in a special register, and we're
+    // in an unsafe function that places restrictions on when you can call it
+    #[cfg(target_arch = "arm")]
+    unsafe {
+        core::arch::asm!("cpsie i", options(nomem, nostack, preserves_flags));
+    };
+}
+
+/// Disable interrupts
+///
+/// Doesn't work in User mode
+#[inline]
+pub fn disable() {
+    // Safety: We're atomically clearing a bit in a special register
+    #[cfg(target_arch = "arm")]
+    unsafe {
+        core::arch::asm!("cpsid i", options(nomem, nostack, preserves_flags));
+    };
+}
+
+/// Run with interrupts disabled
+///
+/// Doesn't work in User mode
+#[inline]
+pub fn free<F, T>(f: F) -> T
+where
+    F: FnOnce() -> T,
+{
+    let cpsr = crate::register::Cpsr::read();
+    disable();
+    let result = f();
+    if cpsr.i() {
+        // Safety: We're only turning them back on if they were on previously
+        unsafe {
+            enable();
+        }
+    }
+    result
+}

--- a/cortex-r/src/lib.rs
+++ b/cortex-r/src/lib.rs
@@ -2,4 +2,9 @@
 
 #![no_std]
 
+#[cfg(feature = "critical-section-single-core")]
 mod critical_section;
+
+pub mod register;
+
+pub mod interrupt;

--- a/cortex-r/src/lib.rs
+++ b/cortex-r/src/lib.rs
@@ -8,3 +8,44 @@ mod critical_section;
 pub mod register;
 
 pub mod interrupt;
+
+/// Generate an SVC call with the given argument
+/// 
+/// Safe to call in Supervisor mode because it pushes LR and SPSR to the stack
+/// before the call, and restores them afterwards.
+#[macro_export]
+macro_rules! svc {
+    ($r0:expr) => {
+        unsafe {
+            core::arch::asm!(r#"
+                // save lr
+                push    {{lr}}
+                // Get spsr
+                mrs     lr, spsr           
+                // save spsr
+                push    {{lr}}                                    
+                // call software interrupt
+                svc {}                     
+                // Get spsr from stack
+                pop     {{lr}}          
+                // Restore spsr
+                msr     spsr, lr      
+                // restore
+                pop     {{lr}}          
+            "#, const $r0);
+        }
+    }
+}
+
+/// Generate an SVC call with the given argument
+/// 
+/// Only works in User mode. Do not call in Supervisor mode (the default mode)
+/// because it will trash your LR and processor status.
+#[macro_export]
+macro_rules! user_svc {
+    ($r0:expr) => {
+        unsafe {
+            core::arch::asm!("svc {}", const $r0);
+        }
+    }
+}

--- a/cortex-r/src/lib.rs
+++ b/cortex-r/src/lib.rs
@@ -10,7 +10,7 @@ pub mod register;
 pub mod interrupt;
 
 /// Generate an SVC call with the given argument
-/// 
+///
 /// Safe to call in Supervisor mode because it pushes LR and SPSR to the stack
 /// before the call, and restores them afterwards.
 #[macro_export]
@@ -38,7 +38,7 @@ macro_rules! svc {
 }
 
 /// Generate an SVC call with the given argument
-/// 
+///
 /// Only works in User mode. Do not call in Supervisor mode (the default mode)
 /// because it will trash your LR and processor status.
 #[macro_export]

--- a/cortex-r/src/lib.rs
+++ b/cortex-r/src/lib.rs
@@ -9,6 +9,8 @@ pub mod register;
 
 pub mod interrupt;
 
+pub mod asm;
+
 /// Generate an SVC call with the given argument
 ///
 /// Safe to call in Supervisor mode because it pushes LR and SPSR to the stack

--- a/cortex-r/src/register/cpsr.rs
+++ b/cortex-r/src/register/cpsr.rs
@@ -1,0 +1,139 @@
+//! Code for managing the *Current Program Status Register*
+
+/// The *Current Program Status Register* (CPSR)
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct Cpsr(u32);
+
+impl Cpsr {
+    /// The bitmask for Negative Result from ALU
+    pub const N_BIT: u32 = 1 << 31;
+    /// The bitmask for Zero Result from ALU
+    pub const Z_BIT: u32 = 1 << 30;
+    /// The bitmask for ALU operation Carry Out
+    pub const C_BIT: u32 = 1 << 29;
+    /// The bitmask for ALU operation Overflow
+    pub const V_BIT: u32 = 1 << 28;
+    /// The bitmask for Cumulative Saturation
+    pub const Q_BIT: u32 = 1 << 27;
+    /// The bitmask for Jazelle State
+    pub const J_BIT: u32 = 1 << 24;
+    /// The bitmask for Endianness
+    pub const E_BIT: u32 = 1 << 9;
+    /// The bitmask for Asynchronous Aborts
+    pub const A_BIT: u32 = 1 << 8;
+    /// The bitmask for Interrupts Enabled
+    pub const I_BIT: u32 = 1 << 7;
+    /// The bitmask for Fast Interrupts Enabled
+    pub const F_BIT: u32 = 1 << 6;
+    /// The bitmask for Thumb state
+    pub const T_BIT: u32 = 1 << 5;
+
+    /// Reads the *Current Program Status Register*
+    #[inline]
+    pub fn read() -> Self {
+        let r: u32;
+        // Safety: Reading this register has no side-effects and is atomic
+        #[cfg(target_arch = "arm")]
+        unsafe {
+            core::arch::asm!("mrs {}, CPSR", out(reg) r, options(nomem, nostack, preserves_flags))
+        };
+        #[cfg(not(target_arch = "arm"))]
+        {
+            r = 0;
+        }
+        Self(r)
+    }
+
+    /// Is the N bit set?
+    #[inline]
+    pub fn n(self) -> bool {
+        (self.0 & Self::N_BIT) != 0
+    }
+
+    /// Is the Z bit set?
+    #[inline]
+    pub fn z(self) -> bool {
+        (self.0 & Self::Z_BIT) != 0
+    }
+
+    /// Is the C bit set?
+    #[inline]
+    pub fn c(self) -> bool {
+        (self.0 & Self::C_BIT) != 0
+    }
+
+    /// Is the V bit set?
+    #[inline]
+    pub fn v(self) -> bool {
+        (self.0 & Self::V_BIT) != 0
+    }
+
+    /// Is the Q bit set?
+    #[inline]
+    pub fn q(self) -> bool {
+        (self.0 & Self::Q_BIT) != 0
+    }
+
+    /// Is the J bit set?
+    #[inline]
+    pub fn j(self) -> bool {
+        (self.0 & Self::J_BIT) != 0
+    }
+
+    /// Is the E bit set?
+    #[inline]
+    pub fn e(self) -> bool {
+        (self.0 & Self::E_BIT) != 0
+    }
+
+    /// Is the A bit set?
+    #[inline]
+    pub fn a(self) -> bool {
+        (self.0 & Self::A_BIT) != 0
+    }
+
+    /// Is the I bit set?
+    #[inline]
+    pub fn i(self) -> bool {
+        (self.0 & Self::I_BIT) != 0
+    }
+
+    /// Is the F bit set?
+    #[inline]
+    pub fn f(self) -> bool {
+        (self.0 & Self::F_BIT) != 0
+    }
+
+    /// Is the T bit set?
+    #[inline]
+    pub fn t(self) -> bool {
+        (self.0 & Self::T_BIT) != 0
+    }
+}
+
+impl core::fmt::Debug for Cpsr {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "CPSR {{ N={} Z={} C={} V={} Q={} J={} E={} A={} I={} F={} T={} }}",
+            self.n() as u8,
+            self.z() as u8,
+            self.c() as u8,
+            self.v() as u8,
+            self.q() as u8,
+            self.j() as u8,
+            self.e() as u8,
+            self.a() as u8,
+            self.i() as u8,
+            self.f() as u8,
+            self.t() as u8,
+        )
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for Cpsr {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(f, "CPSR {{ N={0=31..32} Z={0=30..31} C={0=29..30} V={0=28..29} Q={0=27..28} J={0=24..25} E={0=9..10} A={0=8..9} I={0=7..8} F={0=6..7} T={0=5..6} }}", self.0)
+    }
+}

--- a/cortex-r/src/register/cpsr.rs
+++ b/cortex-r/src/register/cpsr.rs
@@ -29,7 +29,25 @@ impl Cpsr {
     /// The bitmask for Thumb state
     pub const T_BIT: u32 = 1 << 5;
     /// The bitmask for Processor Mode
-    pub const MODE_BITS: u32 = 0x1F;
+    pub const MODE_BITS: u32 = 0b11111;
+    /// The bits for User Mode
+    pub const USR_MODE: u32 = 0b10000;
+    /// The bits for FIQ Mode
+    pub const FIQ_MODE: u32 = 0b10001;
+    /// The bits for IRQ Mode
+    pub const IRQ_MODE: u32 = 0b10010;
+    /// The bits for Supervisor Mode
+    pub const SVC_MODE: u32 = 0b10011;
+    /// The bits for Monitor Mode
+    pub const MON_MODE: u32 = 0b10110;
+    /// The bits for Abort Mode
+    pub const ABT_MODE: u32 = 0b10111;
+    /// The bits for Hyp Mode
+    pub const HYP_MODE: u32 = 0b11010;
+    /// The bits for Undefined Mode
+    pub const UND_MODE: u32 = 0b11011;
+    /// The bits for System Mode
+    pub const SYS_MODE: u32 = 0b11111;
 
     /// Reads the *Current Program Status Register*
     #[inline]

--- a/cortex-r/src/register/cpsr.rs
+++ b/cortex-r/src/register/cpsr.rs
@@ -142,7 +142,7 @@ impl core::fmt::Debug for Cpsr {
             self.i() as u8,
             self.f() as u8,
             self.t() as u8,
-            self.mode() as u8,
+            self.mode(),
         )
     }
 }

--- a/cortex-r/src/register/hactlr.rs
+++ b/cortex-r/src/register/hactlr.rs
@@ -1,0 +1,222 @@
+//! Code for managing the *Hyp Auxiliary Control Register*
+
+/// The *Hyp Auxiliary Control Register* (HACTRL)
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct Hactlr(u32);
+
+impl Hactlr {
+    /// The bitmask for the CPUACTLR bit
+    pub const CPUACTLR_BIT: u32 = 1 << 0;
+    /// The bitmask for the CDBGDCI bit
+    pub const CDBGDCI_BIT: u32 = 1 << 1;
+    /// The bitmask for the FLASHIFREGIONR bit
+    pub const FLASHIFREGIONR_BIT: u32 = 1 << 7;
+    /// The bitmask for the PERIPHPREGIONR bit
+    pub const PERIPHPREGIONR_BIT: u32 = 1 << 8;
+    /// The bitmask for the QOSR bit
+    pub const QOSR_BIT: u32 = 1 << 9;
+    /// The bitmask for the BUSTIMEOUTR bit
+    pub const BUSTIMEOUTR_BIT: u32 = 1 << 10;
+    /// The bitmask for the INTMONR bit
+    pub const INTMONR_BIT: u32 = 1 << 12;
+    /// The bitmask for the ERR bit
+    pub const ERR_BIT: u32 = 1 << 13;
+    /// The bitmask for the TESTR1 bit
+    pub const TESTR1_BIT: u32 = 1 << 15;
+
+    /// Reads the *Hyp Auxiliary Control Register*
+    #[inline]
+    pub fn read() -> Hactlr {
+        let r: u32;
+        // Safety: Reading this register has no side-effects and is atomic
+        #[cfg(target_arch = "arm")]
+        unsafe {
+            core::arch::asm!("mrc p15, 4, {}, c1, c0, 1", out(reg) r, options(nomem, nostack, preserves_flags));
+        }
+        #[cfg(not(target_arch = "arm"))]
+        {
+            r = 0;
+        }
+        Self(r)
+    }
+
+    /// Write to the *Hyp Auxiliary Control Register*
+    #[inline]
+    pub fn write(_value: Self) {
+        // Safety: Writing this register is atomic
+        #[cfg(target_arch = "arm")]
+        unsafe {
+            core::arch::asm!("mcr p15, 4, {}, c1, c0, 1", in(reg) _value.0, options(nomem, nostack, preserves_flags));
+        };
+    }
+
+    /// Modify the *Hyp Auxiliary Control Register*
+    #[inline]
+    pub fn modify<F>(f: F)
+    where
+        F: FnOnce(&mut Self),
+    {
+        let mut value = Self::read();
+        f(&mut value);
+        Self::write(value);
+    }
+
+    /// Is the CPUACTLR bit set?
+    pub fn cpuactlr(self) -> bool {
+        (self.0 & Self::CPUACTLR_BIT) != 0
+    }
+
+    /// Set the CPUACTLR bit
+    pub fn set_cpuactlr(&mut self) {
+        self.0 |= Self::CPUACTLR_BIT;
+    }
+
+    /// Clear the CPUACTLR bit
+    pub fn clear_cpuactlr(&mut self) {
+        self.0 &= !Self::CPUACTLR_BIT;
+    }
+
+    /// Is the CDBGDCI bit set?
+    pub fn cdbgdci(self) -> bool {
+        (self.0 & Self::CDBGDCI_BIT) != 0
+    }
+
+    /// Set the CDBGDCI bit
+    pub fn set_cdbgdci(&mut self) {
+        self.0 |= Self::CDBGDCI_BIT;
+    }
+
+    /// Clear the CDBGDCI bit
+    pub fn clear_cdbgdci(&mut self) {
+        self.0 &= !Self::CDBGDCI_BIT;
+    }
+
+    /// Is the FLASHIFREGIONR bit set?
+    pub fn flashifregionr(self) -> bool {
+        (self.0 & Self::FLASHIFREGIONR_BIT) != 0
+    }
+
+    /// Set the FLASHIFREGIONR bit
+    pub fn set_flashifregionr(&mut self) {
+        self.0 |= Self::FLASHIFREGIONR_BIT;
+    }
+
+    /// Clear the FLASHIFREGIONR bit
+    pub fn clear_flashifregionr(&mut self) {
+        self.0 &= !Self::FLASHIFREGIONR_BIT;
+    }
+
+    /// Is the PERIPHPREGIONR bit set?
+    pub fn periphpregionr(self) -> bool {
+        (self.0 & Self::PERIPHPREGIONR_BIT) != 0
+    }
+
+    /// Set the PERIPHPREGIONR bit
+    pub fn set_periphpregionr(&mut self) {
+        self.0 |= Self::PERIPHPREGIONR_BIT;
+    }
+
+    /// Clear the PERIPHPREGIONR bit
+    pub fn clear_periphpregionr(&mut self) {
+        self.0 &= !Self::PERIPHPREGIONR_BIT;
+    }
+
+    /// Is the QOSR bit set?
+    pub fn qosr(self) -> bool {
+        (self.0 & Self::QOSR_BIT) != 0
+    }
+
+    /// Set the QOSR bit
+    pub fn set_qosr(&mut self) {
+        self.0 |= Self::QOSR_BIT;
+    }
+
+    /// Clear the QOSR bit
+    pub fn clear_qosr(&mut self) {
+        self.0 &= !Self::QOSR_BIT;
+    }
+
+    /// Is the BUSTIMEOUTR bit set?
+    pub fn bustimeoutr(self) -> bool {
+        (self.0 & Self::BUSTIMEOUTR_BIT) != 0
+    }
+
+    /// Set the BUSTIMEOUTR bit
+    pub fn set_bustimeoutr(&mut self) {
+        self.0 |= Self::BUSTIMEOUTR_BIT;
+    }
+
+    /// Clear the BUSTIMEOUTR bit
+    pub fn clear_bustimeoutr(&mut self) {
+        self.0 &= !Self::BUSTIMEOUTR_BIT;
+    }
+
+    /// Is the INTMONR bit set?
+    pub fn intmonr(self) -> bool {
+        (self.0 & Self::INTMONR_BIT) != 0
+    }
+
+    /// Set the INTMONR bit
+    pub fn set_intmonr(&mut self) {
+        self.0 |= Self::INTMONR_BIT;
+    }
+
+    /// Clear the INTMONR bit
+    pub fn clear_intmonr(&mut self) {
+        self.0 &= !Self::INTMONR_BIT;
+    }
+
+    /// Is the ERR bit set?
+    pub fn err(self) -> bool {
+        (self.0 & Self::ERR_BIT) != 0
+    }
+
+    /// Set the ERR bit
+    pub fn set_err(&mut self) {
+        self.0 |= Self::ERR_BIT;
+    }
+
+    /// Clear the ERR bit
+    pub fn clear_err(&mut self) {
+        self.0 &= !Self::ERR_BIT;
+    }
+
+    /// Is the TESTR1 bit set?
+    pub fn testr1(self) -> bool {
+        (self.0 & Self::TESTR1_BIT) != 0
+    }
+
+    /// Set the TESTR1 bit
+    pub fn set_testr1(&mut self) {
+        self.0 |= Self::TESTR1_BIT;
+    }
+
+    /// Clear the TESTR1 bit
+    pub fn clear_testr1(&mut self) {
+        self.0 &= !Self::TESTR1_BIT;
+    }
+}
+
+impl core::fmt::Debug for Hactlr {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "HACTLR {{ CPUACTLR={}, CDBGDCI={}, FLASHIFREGIONR={}, PERIPHPREGIONR={}, QOSR={}, BUSTIMEOUTR={}, INTMONR={}, ERR={}, TESTR1={} }}",
+            self.cpuactlr() as u8,
+            self.cdbgdci() as u8,
+            self.flashifregionr() as u8,
+            self.periphpregionr() as u8,
+            self.qosr() as u8,
+            self.bustimeoutr() as u8,
+            self.intmonr() as u8,
+            self.err() as u8,
+            self.testr1() as u8
+        )
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for Hactlr {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(f, "HACTLR {{ CPUACTLR={0=0..1}, CDBGDCI={0=1..2}, FLASHIFREGIONR={0=7..8}, PERIPHPREGIONR={0=8..9}, QOSR={0=9..10}, BUSTIMEOUTR={0=10..11}, INTMONR={0=12..13}, ERR={0=13..14}, TESTR1={0=15..16} }}", self.0)
+    }
+}

--- a/cortex-r/src/register/hvbar.rs
+++ b/cortex-r/src/register/hvbar.rs
@@ -1,0 +1,36 @@
+//! Code for the *Hyp Vector Base Address Register*
+
+/// The *Hyp Vector Base Address Register* (HVBAR)
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct Hvbar;
+
+impl Hvbar {
+    /// Reads the *Hyp Vector Base Address Register*
+    #[inline]
+    pub fn read() -> usize {
+        let r: usize;
+        #[cfg(target_arch = "arm")]
+        unsafe {
+            core::arch::asm!("mrc p15, 4, {}, c12, c0, 0", out(reg) r, options(nomem, nostack, preserves_flags));
+        }
+        #[cfg(not(target_arch = "arm"))]
+        {
+            r = 0;
+        }
+        r
+    }
+
+    /// Writes the *Hyp Vector Base Address Register*
+    ///
+    /// # Safety
+    ///
+    /// You must supply a correctly-aligned address of a valid Arm Cortex-R
+    /// Vector Table.
+    #[inline]
+    pub unsafe fn write(_value: usize) {
+        #[cfg(target_arch = "arm")]
+        unsafe {
+            core::arch::asm!("mcr p15, 4, {}, c12, c0, 0", in(reg) _value, options(nomem, nostack, preserves_flags));
+        }
+    }
+}

--- a/cortex-r/src/register/midr.rs
+++ b/cortex-r/src/register/midr.rs
@@ -2,6 +2,7 @@
 
 /// The *Main ID Register* (MIDR)
 #[derive(Clone, Copy, PartialEq, Eq)]
+#[repr(transparent)]
 pub struct Midr(u32);
 
 impl Midr {
@@ -12,8 +13,8 @@ impl Midr {
         // Safety: Reading this register has no side-effects and is atomic
         #[cfg(target_arch = "arm")]
         unsafe {
-            core::arch::asm!("mrc p15, 0, {}, c0, c0, 0", out(reg) r, options(nomem, nostack, preserves_flags))
-        };
+            core::arch::asm!("mrc p15, 0, {}, c0, c0, 0", out(reg) r, options(nomem, nostack, preserves_flags));
+        }
         #[cfg(not(target_arch = "arm"))]
         {
             r = 0;

--- a/cortex-r/src/register/midr.rs
+++ b/cortex-r/src/register/midr.rs
@@ -1,0 +1,62 @@
+//! Code for managing the *Main ID Register*
+
+/// The *Main ID Register* (MIDR)
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct Midr(u32);
+
+impl Midr {
+    /// Reads the *Main ID Register*
+    #[inline]
+    pub fn read() -> Midr {
+        let r: u32;
+        // Safety: Reading this register has no side-effects and is atomic
+        #[cfg(target_arch = "arm")]
+        unsafe {
+            core::arch::asm!("mrc p15, 0, {}, c0, c0, 0", out(reg) r, options(nomem, nostack, preserves_flags))
+        };
+        #[cfg(not(target_arch = "arm"))]
+        {
+            r = 0;
+        }
+        Self(r)
+    }
+
+    /// Get the implementer field
+    pub fn implementer(self) -> u32 {
+        self.0 >> 24
+    }
+
+    /// Get the variant field
+    pub fn variant(self) -> u32 {
+        (self.0 >> 20) & 0xF
+    }
+
+    /// Get the arch field
+    pub fn arch(self) -> u32 {
+        (self.0 >> 16) & 0xF
+    }
+
+    /// Get the primary part number field
+    pub fn part_no(self) -> u32 {
+        (self.0 >> 4) & 0xFFF
+    }
+
+    /// Get the rev field
+    pub fn rev(self) -> u32 {
+        self.0 & 0xF
+    }
+}
+
+impl core::fmt::Debug for Midr {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "MIDR {{ implementer=0x{:02x} variant=0x{:x} arch=0x{:x} part_no=0x{:03x} rev=0x{:x} }}",
+        self.implementer(), self.variant(), self.arch(), self.part_no(), self.rev())
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for Midr {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(f, "MIDR {{ implementer=0x{0=24..32:02x} variant=0x{0=20..24:x} arch=0x{0=16..20:x} part_no=0x{0=4..16:03x} rev=0x{0=0..4:x} }}", self.0)
+    }
+}

--- a/cortex-r/src/register/mod.rs
+++ b/cortex-r/src/register/mod.rs
@@ -12,6 +12,18 @@ mod sctlr;
 #[doc(inline)]
 pub use sctlr::Sctlr;
 
+#[cfg(arm_architecture = "v8-r")]
+mod hvbar;
+#[doc(inline)]
+#[cfg(arm_architecture = "v8-r")]
+pub use hvbar::Hvbar;
+
+#[cfg(arm_architecture = "v8-r")]
+mod vbar;
+#[doc(inline)]
+#[cfg(arm_architecture = "v8-r")]
+pub use vbar::Vbar;
+
 // TODO:
 
 // Multiprocessor Affinity Register (MPIDR)

--- a/cortex-r/src/register/mod.rs
+++ b/cortex-r/src/register/mod.rs
@@ -1,0 +1,45 @@
+//! Access registers in Armv7-R and Armv8-R
+
+mod cpsr;
+#[doc(inline)]
+pub use cpsr::Cpsr;
+
+mod midr;
+#[doc(inline)]
+pub use midr::Midr;
+
+mod sctlr;
+#[doc(inline)]
+pub use sctlr::Sctlr;
+
+// TODO:
+
+// Multiprocessor Affinity Register (MPIDR)
+
+// System Control Register
+
+// Auxilliary Control Register
+
+// Coprocessor Access Control Register
+
+// Data Fault Status Register
+
+// Instruction Fault Status Register
+
+// Data Fault Address Register
+
+// Instruction Fault Address Register
+
+// MPU Region Base Address Register
+
+// MPU Region Size and Enable Register
+
+// MPU Region Access Control Register
+
+// MPU Region Number Register
+
+// Context ID Register
+
+// Software Thread ID Register
+
+// Configuration Base Address Register

--- a/cortex-r/src/register/mod.rs
+++ b/cortex-r/src/register/mod.rs
@@ -13,6 +13,12 @@ mod sctlr;
 pub use sctlr::Sctlr;
 
 #[cfg(arm_architecture = "v8-r")]
+mod hactlr;
+#[doc(inline)]
+#[cfg(arm_architecture = "v8-r")]
+pub use hactlr::Hactlr;
+
+#[cfg(arm_architecture = "v8-r")]
 mod hvbar;
 #[doc(inline)]
 #[cfg(arm_architecture = "v8-r")]

--- a/cortex-r/src/register/sctlr.rs
+++ b/cortex-r/src/register/sctlr.rs
@@ -1,0 +1,351 @@
+//! Code for managing the *System Control Register*
+
+/// The *System Control Register* (SCTLR)
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct Sctlr(u32);
+
+impl Sctlr {
+    pub const N_BIT: u32 = 1 << 31;
+
+    /// The bitmask for the Instruction Endianness bit
+    const IE_BIT: u32 = 1 << 31;
+    /// The bitmask for the Thumb Exception Enable bit
+    const TE_BIT: u32 = 1 << 30;
+    /// The bitmask for the Non-Maskable FIQ bit
+    const NMFI_BIT: u32 = 1 << 27;
+    /// The bitmask for the Exception Endianness bit
+    const EE_BIT: u32 = 1 << 25;
+    /// The bitmask for the U bit
+    const U_BIT: u32 = 1 << 22;
+    /// The bitmask for the Fast Interrupt bit
+    const FI_BIT: u32 = 1 << 21;
+    /// The bitmask for the Divide by Zero Fault bit
+    const DZ_BIT: u32 = 1 << 18;
+    /// The bitmask for the Background Region bit
+    const BR_BIT: u32 = 1 << 17;
+    /// The bitmask for the Round Robin bit
+    const RR_BIT: u32 = 1 << 14;
+    /// The bitmask for the Exception Vector Table bit
+    const V_BIT: u32 = 1 << 13;
+    /// The bitmask for the Instruction Cache enable bit
+    const I_BIT: u32 = 1 << 12;
+    /// The bitmask for the Branch Prediction enable bit
+    const Z_BIT: u32 = 1 << 11;
+    /// The bitmask for the SWP bit
+    const SW_BIT: u32 = 1 << 10;
+    /// The bitmask for the Cache enable bit
+    const C_BIT: u32 = 1 << 2;
+    /// The bitmask for the Alignment check bit
+    const A_BIT: u32 = 1 << 1;
+    /// The bitmask for the MPU bit
+    const M_BIT: u32 = 1 << 0;
+
+    /// Reads the *System Control Register*
+    #[inline]
+    pub fn read() -> Self {
+        let r: u32;
+        // Safety: Reading this register has no side-effects and is atomic
+        #[cfg(target_arch = "arm")]
+        unsafe {
+            core::arch::asm!("mrc p15, 0, {}, c1, c0, 0", out(reg) r, options(nomem, nostack, preserves_flags))
+        };
+        #[cfg(not(target_arch = "arm"))]
+        {
+            r = 0;
+        }
+        Self(r)
+    }
+
+    /// Write to the *System Control Register*
+    #[inline]
+    pub fn write(_value: Self) {
+        // Safety: Writing this register is atomic
+        #[cfg(target_arch = "arm")]
+        unsafe {
+            core::arch::asm!("mcr p15, 0, {}, c1, c0, 0", in(reg) _value.0, options(nomem, nostack, preserves_flags))
+        };
+    }
+
+    /// Modify the *System Control Register*
+    #[inline]
+    pub fn modify<F>(f: F)
+    where
+        F: FnOnce(&mut Self),
+    {
+        let mut value = Self::read();
+        f(&mut value);
+        Self::write(value);
+    }
+
+    /// Is the IE bit set?
+    pub fn ie(self) -> bool {
+        (self.0 & Self::IE_BIT) != 0
+    }
+
+    /// Set the IE bit
+    pub fn set_ie(&mut self) {
+        self.0 |= Self::IE_BIT;
+    }
+
+    /// Clear the IE bit
+    pub fn clear_ie(&mut self) {
+        self.0 &= !Self::IE_BIT;
+    }
+
+    /// Is the TE bit set?
+    pub fn te(self) -> bool {
+        (self.0 & Self::TE_BIT) != 0
+    }
+
+    /// Set the TE bit
+    pub fn set_te(&mut self) {
+        self.0 |= Self::TE_BIT;
+    }
+
+    /// Clear the TE bit
+    pub fn clear_te(&mut self) {
+        self.0 &= !Self::TE_BIT;
+    }
+
+    /// Is the NMFI bit set?
+    pub fn nmfi(self) -> bool {
+        (self.0 & Self::NMFI_BIT) != 0
+    }
+
+    /// Set the NMFI bit
+    pub fn set_nmfi(&mut self) {
+        self.0 |= Self::NMFI_BIT;
+    }
+
+    /// Clear the NMFI bit
+    pub fn clear_nmfi(&mut self) {
+        self.0 &= !Self::NMFI_BIT;
+    }
+
+    /// Is the EE bit set?
+    pub fn ee(self) -> bool {
+        (self.0 & Self::EE_BIT) != 0
+    }
+
+    /// Set the EE bit
+    pub fn set_ee(&mut self) {
+        self.0 |= Self::EE_BIT;
+    }
+
+    /// Clear the EE bit
+    pub fn clear_ee(&mut self) {
+        self.0 &= !Self::EE_BIT;
+    }
+
+    /// Is the U bit set?
+    pub fn u(self) -> bool {
+        (self.0 & Self::U_BIT) != 0
+    }
+
+    /// Set the U bit
+    pub fn set_u(&mut self) {
+        self.0 |= Self::U_BIT;
+    }
+
+    /// Clear the U bit
+    pub fn clear_u(&mut self) {
+        self.0 &= !Self::U_BIT;
+    }
+
+    /// Is the FI bit set?
+    pub fn fi(self) -> bool {
+        (self.0 & Self::FI_BIT) != 0
+    }
+
+    /// Set the FI bit
+    pub fn set_fi(&mut self) {
+        self.0 |= Self::FI_BIT;
+    }
+
+    /// Clear the FI bit
+    pub fn clear_fi(&mut self) {
+        self.0 &= !Self::FI_BIT;
+    }
+
+    /// Is the DZ bit set?
+    pub fn dz(self) -> bool {
+        (self.0 & Self::DZ_BIT) != 0
+    }
+
+    /// Set the DZ bit
+    pub fn set_dz(&mut self) {
+        self.0 |= Self::DZ_BIT;
+    }
+
+    /// Clear the DZ bit
+    pub fn clear_dz(&mut self) {
+        self.0 &= !Self::DZ_BIT;
+    }
+
+    /// Is the BR bit set?
+    pub fn br(self) -> bool {
+        (self.0 & Self::BR_BIT) != 0
+    }
+
+    /// Set the BR bit
+    pub fn set_br(&mut self) {
+        self.0 |= Self::BR_BIT;
+    }
+
+    /// Clear the BR bit
+    pub fn clear_br(&mut self) {
+        self.0 &= !Self::BR_BIT;
+    }
+
+    /// Is the RR bit set?
+    pub fn rr(self) -> bool {
+        (self.0 & Self::RR_BIT) != 0
+    }
+
+    /// Set the RR bit
+    pub fn set_rr(&mut self) {
+        self.0 |= Self::RR_BIT;
+    }
+
+    /// Clear the RR bit
+    pub fn clear_rr(&mut self) {
+        self.0 &= !Self::RR_BIT;
+    }
+
+    /// Is the V bit set?
+    pub fn v(self) -> bool {
+        (self.0 & Self::V_BIT) != 0
+    }
+
+    /// Set the V bit
+    pub fn set_v(&mut self) {
+        self.0 |= Self::V_BIT;
+    }
+
+    /// Clear the V bit
+    pub fn clear_v(&mut self) {
+        self.0 &= !Self::V_BIT;
+    }
+
+    /// Is the I bit set?
+    pub fn i(self) -> bool {
+        (self.0 & Self::I_BIT) != 0
+    }
+
+    /// Set the I bit
+    pub fn set_i(&mut self) {
+        self.0 |= Self::I_BIT;
+    }
+
+    /// Clear the I bit
+    pub fn clear_i(&mut self) {
+        self.0 &= !Self::I_BIT;
+    }
+
+    /// Is the Z bit set?
+    pub fn z(self) -> bool {
+        (self.0 & Self::Z_BIT) != 0
+    }
+
+    /// Set the Z bit
+    pub fn set_z(&mut self) {
+        self.0 |= Self::Z_BIT;
+    }
+
+    /// Clear the Z bit
+    pub fn clear_z(&mut self) {
+        self.0 &= !Self::Z_BIT;
+    }
+
+    /// Is the SW bit set?
+    pub fn sw(self) -> bool {
+        (self.0 & Self::SW_BIT) != 0
+    }
+
+    /// Set the SW bit
+    pub fn set_sw(&mut self) {
+        self.0 |= Self::SW_BIT;
+    }
+
+    /// Clear the SW bit
+    pub fn clear_sw(&mut self) {
+        self.0 &= !Self::SW_BIT;
+    }
+
+    /// Is the C bit set?
+    pub fn c(self) -> bool {
+        (self.0 & Self::C_BIT) != 0
+    }
+
+    /// Set the C bit
+    pub fn set_c(&mut self) {
+        self.0 |= Self::C_BIT;
+    }
+
+    /// Clear the C bit
+    pub fn clear_c(&mut self) {
+        self.0 &= !Self::C_BIT;
+    }
+
+    /// Is the A bit set?
+    pub fn a(self) -> bool {
+        (self.0 & Self::A_BIT) != 0
+    }
+
+    /// Set the A bit
+    pub fn set_a(&mut self) {
+        self.0 |= Self::A_BIT;
+    }
+
+    /// Clear the A bit
+    pub fn clear_a(&mut self) {
+        self.0 &= !Self::A_BIT;
+    }
+
+    /// Is the M bit set?
+    pub fn m(self) -> bool {
+        (self.0 & Self::M_BIT) != 0
+    }
+
+    /// Set the M bit
+    pub fn set_m(&mut self) {
+        self.0 |= Self::M_BIT;
+    }
+
+    /// Clear the M bit
+    pub fn clear_m(&mut self) {
+        self.0 &= !Self::M_BIT;
+    }
+}
+
+impl core::fmt::Debug for Sctlr {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "SCTLR {{ IE={} TE={} NMFI={} EE={} U={} FI={} DZ={} BR={} RR={} V={} I={} Z={} SW={} C={} A={} M={} }}",
+            self.ie() as u8,
+            self.te() as u8,
+            self.nmfi() as u8,
+            self.ee() as u8,
+            self.u() as u8,
+            self.fi() as u8,
+            self.dz() as u8,
+            self.br() as u8,
+            self.rr() as u8,
+            self.v() as u8,
+            self.i() as u8,
+            self.z() as u8,
+            self.sw() as u8,
+            self.c() as u8,
+            self.a() as u8,
+            self.m() as u8,
+        )
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for Sctlr {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(f, "SCTLR {{ IE={0=31..32} TE={0=30..31} NMFI={0=27..28} EE={0=25..26} U={0=22..23} FI={0=21..22} DZ={0=18..19} BR={0=17..18} RR={0=14..15} V={0=13..14} I={0=12..13} Z={0=11..12} SW={0=10..11} C={0=2..3} A={0=1..2} M={0=0..1} }}", self.0)
+    }
+}

--- a/cortex-r/src/register/sctlr.rs
+++ b/cortex-r/src/register/sctlr.rs
@@ -2,6 +2,7 @@
 
 /// The *System Control Register* (SCTLR)
 #[derive(Clone, Copy, PartialEq, Eq)]
+#[repr(transparent)]
 pub struct Sctlr(u32);
 
 impl Sctlr {
@@ -47,8 +48,8 @@ impl Sctlr {
         // Safety: Reading this register has no side-effects and is atomic
         #[cfg(target_arch = "arm")]
         unsafe {
-            core::arch::asm!("mrc p15, 0, {}, c1, c0, 0", out(reg) r, options(nomem, nostack, preserves_flags))
-        };
+            core::arch::asm!("mrc p15, 0, {}, c1, c0, 0", out(reg) r, options(nomem, nostack, preserves_flags));
+        }
         #[cfg(not(target_arch = "arm"))]
         {
             r = 0;
@@ -62,7 +63,7 @@ impl Sctlr {
         // Safety: Writing this register is atomic
         #[cfg(target_arch = "arm")]
         unsafe {
-            core::arch::asm!("mcr p15, 0, {}, c1, c0, 0", in(reg) _value.0, options(nomem, nostack, preserves_flags))
+            core::arch::asm!("mcr p15, 0, {}, c1, c0, 0", in(reg) _value.0, options(nomem, nostack, preserves_flags));
         };
     }
 

--- a/cortex-r/src/register/vbar.rs
+++ b/cortex-r/src/register/vbar.rs
@@ -1,0 +1,37 @@
+//! Code for the *Vector Base Address Register*
+
+/// The *Vector Base Address Register* (VBAR)
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct Vbar;
+
+impl Vbar {
+    /// Reads the *Vector Base Address Register*
+    #[inline]
+    pub fn read() -> usize {
+        let r: usize;
+        #[cfg(target_arch = "arm")]
+        unsafe {
+            core::arch::asm!("mrc p15, 0, {}, c12, c0, 0", out(reg) r, options(nomem, nostack, preserves_flags));
+        }
+        #[cfg(not(target_arch = "arm"))]
+        {
+            r = 0;
+        }
+        r
+    }
+
+    /// Writes the *Vector Base Address Register*
+    ///
+    /// # Safety
+    ///
+    /// You must supply a correctly-aligned address of a valid Arm Cortex-R
+    /// Vector Table.
+    #[inline]
+    pub unsafe fn write(_value: usize) {
+        #[cfg(target_arch = "arm")]
+        unsafe {
+            core::arch::asm!("mcr p15, 0, {}, c12, c0, 0", in(reg) _value, options(nomem, nostack, preserves_flags));
+        }
+    }
+}

--- a/criticalup.toml
+++ b/criticalup.toml
@@ -1,7 +1,7 @@
 manifest-version = 1
 
 [products.ferrocene]
-release = "stable-24.11.0"
+release = "beta-25.02-2025-01-25"
 packages = [
     "rustc-${rustc-host}",
     "rust-std-${rustc-host}",


### PR DESCRIPTION
There are a lot of commits here, but they should make sense commit-by-commit. This PR:

* Adds a fork of Google's arm-gic driver with added AArch32 support (see [upstream issue](https://github.com/google/arm-gic/issues/31))
* Fixes the start-up code to correct initialise all the necessary stacks (Armv7-R and Armv8-R have a unique stack pointer per exception mode)
* Initialises .data and .bss sections, so we don't rely on the debugger initialising memory
* Replaces a bunch of magic numbers with constants
* Fixes a bad (but simple) bug in critical-section that was causing the interrupt-mask bit to flip-flop
* Allows users to override the external "C" functions for SVCall and IRQ handling, and the naked function used for FIQ handling (which is just a dummy loop at the moment)
* Fixes bug in Interrupt handler (you have to return to four bytes earlier ... for historical reasons to do with pipelines)
* Adds some basic assembly one-liners, like WFI and DSB.
* Adds a bunch of docs explaining all the symbols we need and the symbols we export.
